### PR TITLE
refactor: update VotingRationaleModal and VotingRecords for improved rationale handling

### DIFF
--- a/src/components/VotingRationaleModal.tsx
+++ b/src/components/VotingRationaleModal.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -64,64 +63,14 @@ export function VotingRationaleModal({
   open,
   onOpenChange,
 }: VotingRationaleModalProps) {
-  // We do not rely on backend-provided rationale; always derive it from anchorUrl when present.
-  const [resolvedRationale, setResolvedRationale] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  // Reset local state when the vote changes
-  useEffect(() => {
-    setResolvedRationale(null);
-    setError(null);
-    setIsLoading(false);
-  }, [vote]);
-
-  // Fetch rationale from anchor URL on demand
-  useEffect(() => {
-    if (!open || !vote || !vote.anchorUrl || resolvedRationale) {
-      return;
-    }
-
-    let cancelled = false;
-
-    const fetchRationale = async () => {
-      try {
-        setIsLoading(true);
-        setError(null);
-
-        const url = resolveAnchorUrl(vote.anchorUrl!);
-        const response = await fetch(url);
-
-        if (!response.ok) {
-          throw new Error(`HTTP ${response.status}`);
-        }
-
-        const rawText = await response.text();
-        const text = extractRationaleText(rawText).trim();
-
-        if (!cancelled) {
-          setResolvedRationale(text || null);
-        }
-      } catch {
-        if (!cancelled) {
-          setError("Unable to load rationale from anchor link.");
-          setResolvedRationale(null);
-        }
-      } finally {
-        if (!cancelled) {
-          setIsLoading(false);
-        }
-      }
-    };
-
-    fetchRationale();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [open, vote, resolvedRationale]);
-
   if (!vote) return null;
+
+  // Prefer rationale text returned directly from the backend/database.
+  // This may contain either plain text or a CIP-100-style JSON structure.
+  const rationaleText =
+    vote.rationale && vote.rationale.trim().length > 0
+      ? extractRationaleText(vote.rationale).trim()
+      : "";
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -178,19 +127,11 @@ export function VotingRationaleModal({
             </div>
             <div className="modal-scrollbar">
               <ScrollArea className="h-[500px] w-full rounded-md border p-4">
-                {isLoading ? (
-                  <div className="text-sm text-muted-foreground">
-                    Loading rationale from anchor link...
-                  </div>
-                ) : error ? (
-                  <div className="text-sm text-destructive">{error}</div>
-                ) : (
-                  <div className="text-sm text-muted-foreground whitespace-pre-wrap leading-relaxed">
-                    {resolvedRationale && resolvedRationale.trim().length > 0
-                      ? resolvedRationale
-                      : "No rationale data provided."}
-                  </div>
-                )}
+                <div className="text-sm text-muted-foreground whitespace-pre-wrap leading-relaxed">
+                  {rationaleText.length > 0
+                    ? rationaleText
+                    : "No rationale data provided."}
+                </div>
               </ScrollArea>
             </div>
           </div>

--- a/src/components/VotingRecords.tsx
+++ b/src/components/VotingRecords.tsx
@@ -95,10 +95,13 @@ export function VotingRecords({
         (vote.voterName || "").toLowerCase().includes(searchQuery.toLowerCase()) ||
         (vote.voterId || "").toLowerCase().includes(searchQuery.toLowerCase());
 
+      const hasRationale =
+        Boolean(vote.rationale && vote.rationale.trim().length > 0);
+
       const matchesVote = voteFilter === "all" || vote.vote.toLowerCase() === voteFilter;
       const matchesRole = roleFilter === "all" || vote.voterType === roleFilter;
       const matchesRationale =
-        rationaleFilter === "all" || (rationaleFilter === "with" && Boolean(vote.anchorUrl));
+        rationaleFilter === "all" || (rationaleFilter === "with" && hasRationale);
 
       return matchesSearch && matchesVote && matchesRole && matchesRationale;
     });

--- a/src/lib/governanceVotingEligibility.ts
+++ b/src/lib/governanceVotingEligibility.ts
@@ -1,4 +1,5 @@
 import type { ProposalType, VoterType } from "@/types/governance";
+import { PROPOSAL_TYPES } from "@/types/governance";
 
 type RoleEligibility = Record<VoterType, boolean>;
 
@@ -14,13 +15,67 @@ const ELIGIBILITY: Record<ProposalType, RoleEligibility> = {
 
 const DEFAULT_ROLE_MATRIX: RoleEligibility = { SPO: false, DRep: true, CC: false };
 
+// Map human–readable governance action labels (as returned by the API / used
+// in filters) to the internal ProposalType enum used by the eligibility matrix.
+// This keeps the rest of the app free to use user–friendly strings while we
+// still resolve to the correct eligibility row here.
+const LABEL_TO_PROPOSAL_TYPE: Record<string, ProposalType> = {
+  // Info / informational actions
+  "Info Action": "InfoAction",
+  InfoAction: "InfoAction",
+
+  // Treasury withdrawals
+  "Treasury Withdrawals": "Treasury",
+  Treasury: "Treasury",
+
+  // New constitution
+  "New Constitution": "NewConstitution",
+  NewConstitution: "NewConstitution",
+
+  // Hard fork initiation
+  "Hard Fork Initiation": "HardForkInitiation",
+  HardForkInitiation: "HardForkInitiation",
+
+  // Protocol parameter changes
+  "Protocol Parameter Change": "ParameterChange",
+  ParameterChange: "ParameterChange",
+
+  // No confidence motions
+  "No Confidence": "NoConfidence",
+  NoConfidence: "NoConfidence",
+
+  // Committee updates
+  "Update Committee": "UpdateCommittee",
+  UpdateCommittee: "UpdateCommittee",
+};
+
+function resolveProposalType(type: ProposalType | string | undefined | null): ProposalType | undefined {
+  if (!type) return undefined;
+
+  // If it's already a valid ProposalType, just use it directly.
+  if (PROPOSAL_TYPES.includes(type as ProposalType)) {
+    return type as ProposalType;
+  }
+
+  // Fallback to explicit label → ProposalType mapping.
+  return LABEL_TO_PROPOSAL_TYPE[type] ?? undefined;
+}
+
+function getRoleMatrixForType(type: ProposalType | string): RoleEligibility {
+  const resolved = resolveProposalType(type);
+  if (resolved && ELIGIBILITY[resolved]) {
+    return ELIGIBILITY[resolved];
+  }
+  return DEFAULT_ROLE_MATRIX;
+}
+
 export function canRoleVoteOnAction(type: ProposalType | string, role: VoterType): boolean {
-  const matrix = ELIGIBILITY[type as ProposalType] ?? DEFAULT_ROLE_MATRIX;
+  const matrix = getRoleMatrixForType(type);
   return matrix[role];
 }
 
 export function getEligibleRoles(type: ProposalType | string): VoterType[] {
-  const matrix = ELIGIBILITY[type as ProposalType] ?? DEFAULT_ROLE_MATRIX;
+  const matrix = getRoleMatrixForType(type);
   return (Object.keys(matrix) as VoterType[]).filter((role) => matrix[role]);
 }
 


### PR DESCRIPTION
- Removed the logic for fetching rationale from anchor URLs in VotingRationaleModal, now preferring rationale text directly from the backend.
- Simplified state management by eliminating loading and error states related to rationale fetching.
- Updated VotingRecords to check for rationale presence using a new helper function, enhancing filtering logic for votes with rationale.
- Improved user feedback by ensuring consistent display of rationale data in the modal.