### PR TITLE
fix: resolve Vercel build timeout on /drep page

### DIFF
--- a/src/components/dreps/DRepPicker.tsx
+++ b/src/components/dreps/DRepPicker.tsx
@@ -10,17 +10,6 @@ import type { EnrichedDRep } from "@/components/dreps/DRepPickerResults";
 
 interface DRepPickerProps {
   initialDreps?: DRepSummary[];
-  initialRationaleStats?: Array<{
-    drepId: string;
-    totalVotesCast: number;
-    rationalesProvided: number;
-    proposalParticipationPercent: number;
-  }>;
-  initialVoteChanges?: Array<{
-    drepId: string;
-    uniqueProposals: number;
-    voteChanges: number;
-  }>;
 }
 
 function formatVotingPower(value: number, decimals: number = 1): string {
@@ -44,16 +33,16 @@ function toPos(fraction: number): number {
 }
 
 
-export default function DRepPicker({ initialDreps, initialRationaleStats, initialVoteChanges }: DRepPickerProps) {
+export default function DRepPicker({ initialDreps }: DRepPickerProps) {
   const t = useTranslations("drep");
   const { activeTheme } = useTheme();
   const isGame = activeTheme.id === "game";
   const isLight = activeTheme.id === "light" || activeTheme.id === "neural";
 
-  // Data hooks
+  // Data hooks — rationaleStats & voteChanges fetched client-side only (too slow for ISR)
   const { dreps: allDreps, isLoading: loadingDreps } = useAllDReps({}, initialDreps);
-  const { dreps: rationaleStats, isLoading: loadingRationale } = useDRepRationaleStats(initialRationaleStats);
-  const { dreps: voteChangeStats, isLoading: loadingChanges } = useDRepVoteChanges(initialVoteChanges);
+  const { dreps: rationaleStats, isLoading: loadingRationale } = useDRepRationaleStats();
+  const { dreps: voteChangeStats, isLoading: loadingChanges } = useDRepVoteChanges();
 
   const isLoading = loadingDreps || loadingRationale || loadingChanges;
 

--- a/src/pages/drep/index.tsx
+++ b/src/pages/drep/index.tsx
@@ -15,11 +15,7 @@ import { cn } from "@/lib/utils";
 import {
   fetchDRepStatsServer,
   fetchAllDRepsServer,
-  fetchDRepRationaleStatsServer,
-  fetchDRepVoteChangesServer,
   type DRepServerItem,
-  type DRepRationaleStatItem,
-  type DRepVoteChangeItem,
 } from "@/lib/serverFetch";
 import type { DRepSummary } from "@/types/drep";
 
@@ -28,8 +24,6 @@ type IntlMessages = typeof import("@/messages/en.json");
 interface InitialDRepData {
   drepStats: DRepStatsApiResponse | null;
   allDreps: DRepServerItem[];
-  rationaleStats: DRepRationaleStatItem[];
-  voteChanges: DRepVoteChangeItem[];
 }
 
 interface DRepDashboardPageProps {
@@ -226,8 +220,6 @@ export default function DRepDashboard({ initialData }: InferGetStaticPropsType<t
                 <TabsContent value="drep-picker" className="mt-0">
                   <DRepPicker
                     initialDreps={initialDreps}
-                    initialRationaleStats={initialData?.rationaleStats}
-                    initialVoteChanges={initialData?.voteChanges}
                   />
                 </TabsContent>
               </Tabs>
@@ -248,17 +240,15 @@ export const getStaticProps: GetStaticProps<DRepDashboardPageProps> = async ({ l
   const messages = (await import(`@/messages/${locale ?? "en"}.json`)).default;
 
   try {
-    const [drepStats, allDreps, rationaleStats, voteChanges] = await Promise.all([
+    const [drepStats, allDreps] = await Promise.all([
       fetchDRepStatsServer(),
       fetchAllDRepsServer(),
-      fetchDRepRationaleStatsServer(),
-      fetchDRepVoteChangesServer(),
     ]);
 
     return {
       props: {
         messages,
-        initialData: { drepStats, allDreps, rationaleStats, voteChanges },
+        initialData: { drepStats, allDreps },
       },
       revalidate: 60,
     };
@@ -267,7 +257,7 @@ export const getStaticProps: GetStaticProps<DRepDashboardPageProps> = async ({ l
     return {
       props: {
         messages,
-        initialData: { drepStats: null, allDreps: [], rationaleStats: [], voteChanges: [] },
+        initialData: { drepStats: null, allDreps: [] },
       },
       revalidate: 30,
     };


### PR DESCRIPTION
## Summary
- Removed `fetchDRepRationaleStatsServer()` and `fetchDRepVoteChangesServer()` from `/drep` page's `getStaticProps`
- These N+1 aggregations were making hundreds of backend API calls at build time, exceeding Vercel's 60-second timeout
- Data is now fetched client-side via existing SWR hooks (`useDRepRationaleStats`, `useDRepVoteChanges`)
- Also eliminates the 1.91 MB page data warning (was well over the 128 kB threshold)

