### PR TITLE
Update CIP-179 survey support to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test:cip179": "esbuild src/lib/surveyMetadata.test.mts --bundle --platform=node --format=esm --external:@meshsdk/core --outfile=.next/cip179-test.mjs && node --test .next/cip179-test.mjs"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -16,6 +17,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@meshsdk/core": "1.9.0-beta.87",
     "@meshsdk/react": "1.9.0-beta.87",
+    "@noble/hashes": "2.2.0",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-popover": "^1.1.15",
@@ -27,6 +29,7 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@reduxjs/toolkit": "^2.10.1",
     "@types/d3": "^7.4.3",
+    "cip-179": "0.2.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "d3": "^7.9.0",
@@ -61,6 +64,7 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "dotenv": "^17.2.3",
+    "esbuild": "0.28.1",
     "eslint": "^8",
     "eslint-config-next": "15.5.14",
     "postcss": "^8",

--- a/src/components/governance/Cip179ResponseForm.tsx
+++ b/src/components/governance/Cip179ResponseForm.tsx
@@ -1,0 +1,194 @@
+import { useEffect, useMemo, useState } from "react";
+import { ChevronDown, ChevronUp } from "lucide-react";
+import type { AnswerItem, Question, SurveyDefinition } from "cip-179";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { fetchAnchorJson, schemaAcceptsText } from "@/lib/cip179Content";
+import { cn } from "@/lib/utils";
+
+type Draft =
+  | { type: "singleChoice"; optionIndex: number }
+  | { type: "multiSelect"; optionIndices: number[] }
+  | { type: "ranking"; ranking: number[] }
+  | { type: "numeric"; value: string }
+  | { type: "pointsAllocation"; points: string[] }
+  | { type: "rating"; ratings: Array<string | null> }
+  | { type: "custom"; value: string };
+
+interface Props {
+  definition: SurveyDefinition;
+  disabled?: boolean;
+  onAnswersChange: (answers: AnswerItem[] | null) => void;
+}
+
+function optionLabels(question: Question): string[] {
+  if (!("options" in question)) return [];
+  return question.options.type === "options"
+    ? [...question.options.labels]
+    : Array.from({ length: question.options.count }, (_, index) => `Option ${index + 1}`);
+}
+
+function ratingValues(question: Extract<Question, { type: "rating" }>): Array<{ value: bigint; label: string }> {
+  if (question.scale.type === "labels") {
+    return question.scale.labels.map((label, index) => ({ value: BigInt(index), label }));
+  }
+  if (question.scale.type === "count") {
+    return Array.from({ length: question.scale.count }, (_, index) => ({ value: BigInt(index), label: String(index + 1) }));
+  }
+  return [];
+}
+
+export function answerFor(question: Question, index: number, draft: Draft | undefined): AnswerItem | null | false {
+  if (!draft) return question.required ? false : null;
+  switch (question.type) {
+    case "singleChoice":
+      return draft.type === "singleChoice"
+        ? { type: "singleChoice", questionIndex: index, optionIndex: draft.optionIndex }
+        : false;
+    case "multiSelect":
+      return draft.type === "multiSelect" && draft.optionIndices.length >= question.minSelections && draft.optionIndices.length <= question.maxSelections
+        ? { type: "multiSelect", questionIndex: index, optionIndices: draft.optionIndices }
+        : false;
+    case "ranking":
+      return draft.type === "ranking" && draft.ranking.length >= question.minRanked && draft.ranking.length <= question.maxRanked
+        ? { type: "ranking", questionIndex: index, ranking: draft.ranking }
+        : false;
+    case "numericRange": {
+      if (draft.type !== "numeric" || !/^-?\d+$/.test(draft.value)) return false;
+      const value = BigInt(draft.value);
+      const step = question.constraints.step;
+      return value >= question.constraints.min && value <= question.constraints.max && (!step || (value - question.constraints.min) % step === BigInt(0))
+        ? { type: "numeric", questionIndex: index, value }
+        : false;
+    }
+    case "pointsAllocation": {
+      if (draft.type !== "pointsAllocation" || draft.points.some((points) => !/^\d+$/.test(points))) return false;
+      const exactPoints = draft.points.map(BigInt);
+      if (exactPoints.some((value) => value > BigInt(question.budget))) return false;
+      const points = exactPoints.map(Number);
+      return exactPoints.reduce((sum, value) => sum + value, BigInt(0)) === BigInt(question.budget)
+        ? {
+            type: "pointsAllocation",
+            questionIndex: index,
+            allocations: points.flatMap((value, optionIndex) => value > 0 ? [{ optionIndex, points: value }] : []),
+          }
+        : false;
+    }
+    case "rating": {
+      if (draft.type !== "rating") return false;
+      if (draft.ratings.some((value) => value !== null && !/^-?\d+$/.test(value))) return false;
+      const ratings = draft.ratings.flatMap((value, optionIndex) =>
+        value === null ? [] : [{ optionIndex, rating: BigInt(value) }]
+      );
+      const validRating = ({ rating }: { rating: bigint }) => {
+        if (question.scale.type === "labels") return rating >= BigInt(0) && rating < BigInt(question.scale.labels.length);
+        if (question.scale.type === "count") return rating >= BigInt(0) && rating < BigInt(question.scale.count);
+        const { min, max, step } = question.scale.constraints;
+        return rating >= min && rating <= max && (!step || (rating - min) % step === BigInt(0));
+      };
+      return ratings.length > 0 && (!question.requireAll || ratings.length === draft.ratings.length)
+        && ratings.every(validRating)
+        ? { type: "rating", questionIndex: index, ratings }
+        : false;
+    }
+    case "custom":
+      return draft.type === "custom" && draft.value.trim() && new TextEncoder().encode(draft.value.trim()).length <= 64
+        ? { type: "custom", questionIndex: index, value: draft.value.trim() }
+        : false;
+  }
+}
+
+export function Cip179ResponseForm({ definition, disabled = false, onAnswersChange }: Props) {
+  const [drafts, setDrafts] = useState<Record<number, Draft>>({});
+  const [customText, setCustomText] = useState<Record<number, boolean>>({});
+
+  useEffect(() => {
+    setDrafts({});
+    setCustomText({});
+    definition.questions.forEach((question, index) => {
+      if (question.type !== "custom") return;
+      void fetchAnchorJson(question.methodSchema)
+        .then((schema) => setCustomText((current) => ({ ...current, [index]: schemaAcceptsText(schema) })))
+        .catch(() => setCustomText((current) => ({ ...current, [index]: false })));
+    });
+  }, [definition]);
+
+  const answers = useMemo(() => {
+    const result: AnswerItem[] = [];
+    for (let index = 0; index < definition.questions.length; index += 1) {
+      const answer = answerFor(definition.questions[index], index, drafts[index]);
+      if (answer === false) return null;
+      if (answer) result.push(answer);
+    }
+    return result;
+  }, [definition, drafts]);
+
+  useEffect(() => onAnswersChange(answers), [answers, onAnswersChange]);
+
+  const update = (index: number, draft: Draft | undefined) => {
+    setDrafts((current) => {
+      const next = { ...current };
+      if (draft) next[index] = draft;
+      else delete next[index];
+      return next;
+    });
+  };
+
+  return (
+    <div className="space-y-3">
+      {definition.questions.map((question, index) => {
+        const labels = optionLabels(question);
+        const draft = drafts[index];
+        return (
+          <div key={index} className="border border-border p-3">
+            <div className="flex justify-between gap-3">
+              <p className="text-sm font-medium">{index + 1}. {question.prompt}</p>
+              {question.required ? <span className="text-xs text-destructive">Required</span> : null}
+            </div>
+
+            {question.type === "singleChoice" ? (
+              <div className="mt-2 flex flex-wrap gap-2">
+                {labels.map((label, optionIndex) => (
+                  <Button key={optionIndex} type="button" size="sm" variant={draft?.type === "singleChoice" && draft.optionIndex === optionIndex ? "secondary" : "outline"} disabled={disabled}
+                    onClick={() => update(index, { type: "singleChoice", optionIndex })}>{label}</Button>
+                ))}
+              </div>
+            ) : question.type === "multiSelect" ? (
+              <div className="mt-2 space-y-1">
+                {labels.map((label, optionIndex) => {
+                  const selected = draft?.type === "multiSelect" ? draft.optionIndices : [];
+                  return <label key={optionIndex} className="flex gap-2 text-sm"><input type="checkbox" checked={selected.includes(optionIndex)} disabled={disabled || (!selected.includes(optionIndex) && selected.length >= question.maxSelections)} onChange={(event) => update(index, { type: "multiSelect", optionIndices: event.target.checked ? [...selected, optionIndex].sort((left, right) => left - right) : selected.filter((value) => value !== optionIndex) })} />{label}</label>;
+                })}
+                <p className="text-xs text-muted-foreground">Choose {question.minSelections} to {question.maxSelections}.</p>
+              </div>
+            ) : question.type === "ranking" ? (
+              <div className="mt-2 space-y-2">
+                {labels.map((label, optionIndex) => {
+                  const ranking = draft?.type === "ranking" ? draft.ranking : [];
+                  const position = ranking.indexOf(optionIndex);
+                  return <div key={optionIndex} className="flex items-center gap-2 text-sm"><input type="checkbox" checked={position >= 0} disabled={disabled || (position < 0 && ranking.length >= question.maxRanked)} onChange={(event) => update(index, { type: "ranking", ranking: event.target.checked ? [...ranking, optionIndex] : ranking.filter((value) => value !== optionIndex) })} /><span className="flex-1">{position >= 0 ? `${position + 1}. ` : ""}{label}</span>{position >= 0 ? <><Button type="button" size="icon" variant="ghost" disabled={disabled || position === 0} onClick={() => { const next = [...ranking]; [next[position - 1], next[position]] = [next[position], next[position - 1]]; update(index, { type: "ranking", ranking: next }); }}><ChevronUp className="h-4 w-4" /></Button><Button type="button" size="icon" variant="ghost" disabled={disabled || position === ranking.length - 1} onClick={() => { const next = [...ranking]; [next[position + 1], next[position]] = [next[position], next[position + 1]]; update(index, { type: "ranking", ranking: next }); }}><ChevronDown className="h-4 w-4" /></Button></> : null}</div>;
+                })}
+              </div>
+            ) : question.type === "numericRange" ? (
+              <input className="mt-2 h-9 w-full border border-input bg-background px-3 text-sm" type="number" min={String(question.constraints.min)} max={String(question.constraints.max)} step={String(question.constraints.step ?? BigInt(1))} disabled={disabled} value={draft?.type === "numeric" ? draft.value : ""} onChange={(event) => update(index, { type: "numeric", value: event.target.value })} />
+            ) : question.type === "pointsAllocation" ? (
+              <div className="mt-2 space-y-2">{labels.map((label, optionIndex) => { const points = draft?.type === "pointsAllocation" ? draft.points : labels.map(() => "0"); return <label key={optionIndex} className="flex items-center justify-between gap-3 text-sm"><span>{label}</span><input className="h-8 w-24 border border-input bg-background px-2" type="number" min={0} max={question.budget} step={1} disabled={disabled} value={points[optionIndex]} onChange={(event) => { const next = [...points]; next[optionIndex] = event.target.value; update(index, { type: "pointsAllocation", points: next }); }} /></label>; })}<p className={cn("text-xs", draft?.type === "pointsAllocation" && answerFor(question, index, draft) !== false ? "text-muted-foreground" : "text-amber-700")}>Allocate exactly {question.budget} points.</p></div>
+            ) : question.type === "rating" ? (
+              <div className="mt-2 space-y-2">{labels.map((label, optionIndex) => { const ratings = draft?.type === "rating" ? draft.ratings : labels.map(() => null); return <label key={optionIndex} className="flex items-center justify-between gap-3 text-sm"><span>{label}</span>{question.scale.type === "numeric" ? <input className="h-8 w-24 border border-input bg-background px-2" type="number" min={String(question.scale.constraints.min)} max={String(question.scale.constraints.max)} step={String(question.scale.constraints.step ?? BigInt(1))} disabled={disabled} value={ratings[optionIndex] ?? ""} onChange={(event) => { const next = [...ratings]; next[optionIndex] = event.target.value || null; update(index, { type: "rating", ratings: next }); }} /> : <select className="h-8 border border-input bg-background px-2" disabled={disabled} value={ratings[optionIndex] ?? ""} onChange={(event) => { const next = [...ratings]; next[optionIndex] = event.target.value || null; update(index, { type: "rating", ratings: next }); }}><option value="">Not rated</option>{ratingValues(question).map((value) => <option key={String(value.value)} value={String(value.value)}>{value.label}</option>)}</select>}</label>; })}</div>
+            ) : customText[index] ? (
+              <div className="mt-2 space-y-1">
+                <Textarea disabled={disabled} value={draft?.type === "custom" ? draft.value : ""} onChange={(event) => update(index, { type: "custom", value: event.target.value })} />
+                <p className="text-xs text-muted-foreground">Maximum 64 UTF-8 bytes.</p>
+              </div>
+            ) : (
+              <p className="mt-2 text-xs text-muted-foreground">CGov can display this custom question, but its verified schema is not a text response schema.</p>
+            )}
+
+            {draft && !question.required ? <Button type="button" variant="ghost" size="sm" className="mt-2" disabled={disabled} onClick={() => update(index, undefined)}>Skip question</Button> : null}
+          </div>
+        );
+      })}
+      {answers === null ? <p className="text-xs text-amber-700">Complete all required questions and correct invalid values to attach this survey response.</p> : null}
+    </div>
+  );
+}

--- a/src/components/governance/LinkedSurveyPanel.tsx
+++ b/src/components/governance/LinkedSurveyPanel.tsx
@@ -1,23 +1,14 @@
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { VoteProgress } from "@/components/ui/vote-progress";
+import type { Question, SurveyDefinition } from "cip-179";
+import type { ArtifactQuestion, ArtifactRoleTally } from "cip-179/tally";
 import type {
-  ProposalSurveyMethodResult,
   ProposalSurveyResponse,
-  ProposalSurveyRoleResult,
-  ProposalSurveyTallyPhase,
   ProposalSurveyTallyResponse,
-  ResponderRole,
-  SurveyQuestion,
-  SurveyWeightingMode,
 } from "@/types/governance";
-import {
-  BUILTIN_SURVEY_METHODS,
-  isCustomSurveyMethod,
-} from "@/lib/surveyMetadata";
-import type { VoteSegment } from "@/lib/voteBreakdownCalculator";
 import { cn } from "@/lib/utils";
+import { useCip179Presentation } from "@/hooks/useCip179Presentation";
 
 interface LinkedSurveyPanelProps {
   survey: ProposalSurveyResponse | null;
@@ -29,511 +20,83 @@ interface LinkedSurveyPanelProps {
   isGame?: boolean;
 }
 
-interface SurveyLegendItem {
-  label: string;
-  value: number;
-  percent: number;
-  color: string;
-}
-
-interface ChoiceMethodResultShape {
-  options: string[];
-  optionTotals: number[];
-}
-
-interface NumericMethodResultShape {
-  count: number;
-  min: number | null;
-  max: number | null;
-  mean: number | null;
-}
-
-interface CustomMethodResultShape {
-  customValueTotals: Record<string, number>;
-}
-
-const ROLE_ORDER: ResponderRole[] = ["DRep", "SPO", "CC", "Stakeholder"];
-
-const ROLE_LABELS: Record<ResponderRole, string> = {
-  DRep: "DReps",
-  SPO: "SPOs",
-  CC: "CC",
-  Stakeholder: "Stakeholders",
+const ROLE_NAMES: Record<number, string> = {
+  0: "DReps",
+  1: "SPOs",
+  2: "Constitutional Committee",
+  3: "Stakeholders",
+  4: "Keyholders",
 };
 
-const QUESTION_DONUT_COLORS = [
-  "#22C55E",
-  "#8C200B",
-  "#0EA5E9",
-  "#F59E0B",
-  "#8B5CF6",
-  "#EC4899",
-  "#14B8A6",
-  "#64748B",
-];
-
-const compactFormatter = new Intl.NumberFormat("en-US", {
-  notation: "compact",
-  maximumFractionDigits: 1,
-});
-
-const integerFormatter = new Intl.NumberFormat("en-US", {
-  maximumFractionDigits: 0,
-});
-
-const decimalFormatter = new Intl.NumberFormat("en-US", {
-  maximumFractionDigits: 2,
-});
-
-function getTallyPhaseLabel(
-  phase: ProposalSurveyTallyPhase,
-  finalizationEpoch: number | null
-): string {
-  if (phase === "provisional") {
-    return finalizationEpoch !== null
-      ? `Provisional until epoch ${integerFormatter.format(finalizationEpoch)}`
-      : "Provisional";
+function labels(question: Question): string[] {
+  if ("options" in question && question.options.type === "options") {
+    return [...question.options.labels];
   }
-
-  if (phase === "finalization_pending") {
-    return "Finalization pending";
+  if (question.type === "rating" && question.scale.type === "labels") {
+    return [...question.scale.labels];
   }
-
-  return "Finalized";
+  const count = "options" in question && question.options.type === "count"
+    ? question.options.count
+    : 0;
+  return Array.from({ length: count }, (_, index) => `Option ${index + 1}`);
 }
 
-function getTallyPhaseTone(
-  phase: ProposalSurveyTallyPhase
-): "outline" | "secondary" {
-  return phase === "finalized" ? "secondary" : "outline";
-}
-
-function getApplicableRoles(
-  survey: ProposalSurveyResponse | null,
-  tally: ProposalSurveyTallyResponse | null
-): ResponderRole[] {
-  const linkedRoleWeighting = survey?.linkValidation.linkedRoleWeighting;
-  if (linkedRoleWeighting && Object.keys(linkedRoleWeighting).length > 0) {
-    return ROLE_ORDER.filter((role) => linkedRoleWeighting[role]);
+function ResultRows({ result, question }: { result: ArtifactQuestion; question: Question }) {
+  if (result.kind === "custom") {
+    return <p className="text-sm text-muted-foreground">{result.answeredCount} responses</p>;
   }
-
-  const surveyRoleWeighting = survey?.surveyDetails?.roleWeighting;
-  if (surveyRoleWeighting && Object.keys(surveyRoleWeighting).length > 0) {
-    return ROLE_ORDER.filter((role) => surveyRoleWeighting[role]);
-  }
-
-  const tallyRoles = new Set(
-    tally?.roleResults.map((roleResult) => roleResult.responderRole) ?? []
-  );
-  return ROLE_ORDER.filter((role) => tallyRoles.has(role));
-}
-
-function getRoleWeightingMode(
-  role: ResponderRole,
-  survey: ProposalSurveyResponse | null,
-  tally: ProposalSurveyTallyResponse | null
-): SurveyWeightingMode | null {
-  return (
-    survey?.linkValidation.linkedRoleWeighting?.[role] ??
-    survey?.surveyDetails?.roleWeighting?.[role] ??
-    tally?.roleResults.find((roleResult) => roleResult.responderRole === role)
-      ?.weightingMode ??
-    null
-  );
-}
-
-function getRoleResult(
-  role: ResponderRole,
-  tally: ProposalSurveyTallyResponse | null
-): ProposalSurveyRoleResult | null {
-  return (
-    tally?.roleResults.find((roleResult) => roleResult.responderRole === role) ??
-    null
-  );
-}
-
-function getMethodResult(
-  role: ResponderRole,
-  questionId: string,
-  tally: ProposalSurveyTallyResponse | null
-): ProposalSurveyMethodResult | null {
-  return (
-    getRoleResult(role, tally)?.methodResults.find((result) => {
-      const resultRecord = result as Record<string, unknown>;
-      return resultRecord.questionId === questionId;
-    }) ?? null
-  );
-}
-
-function parseChoiceMethodResult(
-  result: ProposalSurveyMethodResult | null
-): ChoiceMethodResultShape | null {
-  if (!result) return null;
-  const record = result as Record<string, unknown>;
-  const options = Array.isArray(record.options)
-    ? record.options.filter(
-        (option): option is string => typeof option === "string"
-      )
-    : [];
-  const optionTotals = Array.isArray(record.optionTotals)
-    ? record.optionTotals.filter(
-        (total): total is number => typeof total === "number"
-      )
-    : [];
-  return {
-    options,
-    optionTotals,
-  };
-}
-
-function parseNumericMethodResult(
-  result: ProposalSurveyMethodResult | null
-): NumericMethodResultShape | null {
-  if (!result) return null;
-  const record = result as Record<string, unknown>;
-  return {
-    count: typeof record.count === "number" ? record.count : 0,
-    min: typeof record.min === "number" ? record.min : null,
-    max: typeof record.max === "number" ? record.max : null,
-    mean: typeof record.mean === "number" ? record.mean : null,
-  };
-}
-
-function parseCustomMethodResult(
-  result: ProposalSurveyMethodResult | null
-): CustomMethodResultShape | null {
-  if (!result) return null;
-  const record = result as Record<string, unknown>;
-  const customValueTotals =
-    record.customValueTotals &&
-    typeof record.customValueTotals === "object" &&
-    !Array.isArray(record.customValueTotals)
-      ? (record.customValueTotals as Record<string, number>)
-      : {};
-
-  return {
-    customValueTotals,
-  };
-}
-
-function formatWeightedValue(
-  value: number,
-  weightingMode: SurveyWeightingMode | null
-): string {
-  if (weightingMode === "CredentialBased") {
-    return integerFormatter.format(value);
-  }
-
-  if (Math.abs(value) >= 1000) {
-    return `${compactFormatter.format(value)} ADA`;
-  }
-
-  return `${decimalFormatter.format(value)} ADA`;
-}
-
-function formatCenterValue(
-  value: number,
-  weightingMode: SurveyWeightingMode | null
-): string {
-  if (weightingMode === "CredentialBased") {
-    return integerFormatter.format(value);
-  }
-
-  return Math.abs(value) >= 1000
-    ? `${compactFormatter.format(value)} ADA`
-    : `${decimalFormatter.format(value)} ADA`;
-}
-
-function formatNumericValue(value: number | null): string {
-  if (value === null) {
-    return "-";
-  }
-
-  return Number.isInteger(value)
-    ? integerFormatter.format(value)
-    : decimalFormatter.format(value);
-}
-
-function formatCustomValue(rawKey: string): string {
-  try {
-    const parsed = JSON.parse(rawKey) as unknown;
-    if (typeof parsed === "string") {
-      return parsed;
-    }
-    return JSON.stringify(parsed);
-  } catch {
-    return rawKey;
-  }
-}
-
-function buildLegendItems(
-  question: SurveyQuestion,
-  result: ChoiceMethodResultShape | null
-): SurveyLegendItem[] {
-  const optionLabels =
-    question.options && question.options.length > 0
-      ? question.options
-      : result?.options ?? [];
-  const optionTotals = result?.optionTotals ?? [];
-  const totalSelections = optionTotals.reduce((sum, value) => sum + value, 0);
-
-  return optionLabels.map((label, index) => {
-    const value = optionTotals[index] ?? 0;
-    return {
-      label,
-      value,
-      percent: totalSelections > 0 ? (value / totalSelections) * 100 : 0,
-      color: QUESTION_DONUT_COLORS[index % QUESTION_DONUT_COLORS.length],
-    };
-  });
-}
-
-function buildChoiceSegments(items: SurveyLegendItem[]): VoteSegment[] {
-  return items
-    .filter((item) => item.value > 0)
-    .map((item, index) => ({
-      type: `option-${index}`,
-      percent: item.percent,
-      value: item.value,
-      color: item.color,
-      label: item.label,
-    }));
-}
-
-function SummaryCard({
-  role,
-  weightingMode,
-  title,
-  rows,
-  emptyMessage,
-  isGame,
-  children,
-}: {
-  role: ResponderRole;
-  weightingMode: SurveyWeightingMode | null;
-  title?: string;
-  rows: Array<{ label: string; value: string }>;
-  emptyMessage?: string;
-  isGame: boolean;
-  children?: React.ReactNode;
-}) {
-  const hasRows = rows.length > 0;
-
-  return (
-    <div
-      className={cn(
-        "w-full rounded-3xl border px-4 py-4 shadow-elevation-2",
-        isGame
-          ? "game-detail-card"
-          : "border-border bg-card dark:rounded-none dark:border-[#0bd1a2] dark:bg-transparent dark:shadow-none"
-      )}
-    >
-      <div className="flex flex-wrap items-start justify-between gap-2">
-        <div className="min-w-0 flex-1">
-          <div
-            className={cn(
-              "text-sm font-medium",
-              isGame ? "text-white" : "text-muted-foreground"
-            )}
-          >
-            {ROLE_LABELS[role]}
+  if (result.kind === "numeric") {
+    return (
+      <div className="space-y-1 text-sm">
+        <p>{result.answeredCount} responses</p>
+        {result.values.map((value) => (
+          <div key={value.value} className="flex justify-between gap-4">
+            <span>{value.value}</span><span>{value.count}</span>
           </div>
-          {title ? (
-            <div
-              className={cn(
-                "mt-1 break-words text-base font-semibold",
-                isGame ? "text-white" : "text-foreground dark:text-[#0bd1a2]"
-              )}
-            >
-              {title}
-            </div>
-          ) : null}
-        </div>
-        {weightingMode ? (
-          <Badge
-            variant="outline"
-            className="max-w-full whitespace-normal break-words rounded-none px-2 py-1 text-2xs leading-tight"
-          >
-            {weightingMode}
-          </Badge>
-        ) : null}
+        ))}
       </div>
-
-      {hasRows ? (
-        <div className="mt-4 space-y-2">
-          {children}
-          {rows.map((row) => (
-            <div
-              key={`${role}-${title}-${row.label}`}
-              className="flex items-start justify-between gap-3 text-sm"
-            >
-              <span
-                className={cn(
-                  "min-w-0 flex-1 text-muted-foreground",
-                  isGame && "text-white/70"
-                )}
-              >
-                {row.label}
-              </span>
-              <span
-                className={cn(
-                  "shrink-0 font-mono",
-                  isGame ? "text-white" : "text-foreground dark:text-[#0bd1a2]"
-                )}
-              >
-                {row.value}
-              </span>
-            </div>
-          ))}
+    );
+  }
+  if (result.kind === "options") {
+    const names = labels(question);
+    return (
+      <div className="space-y-1 text-sm">
+        {result.optionCounts.map((count, index) => (
+          <div key={index} className="flex justify-between gap-4">
+            <span>{names[index] ?? `Option ${index + 1}`}</span><span>{count}</span>
+          </div>
+        ))}
+      </div>
+    );
+  }
+  const names = labels(question);
+  return (
+    <div className="space-y-1 text-sm">
+      {result.perOption.map((value, index) => (
+        <div key={index} className="flex justify-between gap-4">
+          <span>{names[index] ?? `Option ${index + 1}`}</span>
+          <span>{value.count} responses</span>
         </div>
-      ) : (
-        <div
-          className={cn(
-            "mt-4 text-sm text-muted-foreground",
-            isGame && "text-white/70"
-          )}
-        >
-          {emptyMessage ?? "No valid responses have been tallied for this role yet."}
-        </div>
-      )}
+      ))}
     </div>
   );
 }
 
-function ChoiceRoleBlock({
-  question,
-  role,
-  weightingMode,
-  result,
-}: {
-  question: SurveyQuestion;
-  role: ResponderRole;
-  weightingMode: SurveyWeightingMode | null;
-  result: ProposalSurveyMethodResult | null;
+function RoleResult({ role, question, questionIndex }: {
+  role: ArtifactRoleTally;
+  question: Question;
+  questionIndex: number;
 }) {
-  const choiceResult = parseChoiceMethodResult(result);
-  const items = buildLegendItems(question, choiceResult);
-  const segments = buildChoiceSegments(items);
-  const total = items.reduce((sum, item) => sum + item.value, 0);
-
+  const result = role.questions[questionIndex];
+  if (!result) return null;
   return (
-    <div className="flex min-w-0 w-full flex-col items-center gap-3 sm:w-[240px]">
-      <div className="flex w-full items-center justify-center">
-        <VoteProgress
-          title={ROLE_LABELS[role]}
-          segments={segments}
-          valueUnit={weightingMode === "CredentialBased" ? "count" : "ada"}
-          className="shrink-0"
-          fixedWidth={240}
-          showTooltip
-          animate={false}
-          interactive
-          centerText={total > 0 ? formatCenterValue(total, weightingMode) : undefined}
-        />
+    <div className="border border-border p-3">
+      <div className="mb-2 flex items-center justify-between gap-3">
+        <span className="text-sm font-semibold">{ROLE_NAMES[role.role] ?? `Role ${role.role}`}</span>
+        <span className="text-xs text-muted-foreground">{role.responders.length} responders</span>
       </div>
+      <ResultRows result={result} question={question} />
     </div>
-  );
-}
-
-function NumericRangeRoleCard({
-  question,
-  role,
-  weightingMode,
-  result,
-  isGame,
-}: {
-  question: SurveyQuestion;
-  role: ResponderRole;
-  weightingMode: SurveyWeightingMode | null;
-  result: ProposalSurveyMethodResult | null;
-  isGame: boolean;
-}) {
-  const numericResult = parseNumericMethodResult(result);
-  const constraints = question.numericConstraints;
-  const hasResponses = (numericResult?.count ?? 0) > 0 && constraints;
-  const numericMean = numericResult?.mean ?? null;
-  const rangeSpan =
-    constraints && constraints.maxValue > constraints.minValue
-      ? constraints.maxValue - constraints.minValue
-      : 0;
-  const meanPosition =
-    hasResponses && numericMean !== null && rangeSpan > 0
-      ? Math.min(
-          100,
-          Math.max(
-            0,
-            ((numericMean - constraints.minValue) / rangeSpan) * 100
-          )
-        )
-      : 0;
-
-  return (
-    <SummaryCard
-      role={role}
-      weightingMode={weightingMode}
-      isGame={isGame}
-      rows={
-        hasResponses
-          ? [
-              {
-                label: "Count",
-                value: integerFormatter.format(numericResult?.count ?? 0),
-              },
-              {
-                label: "Min",
-                value: formatNumericValue(numericResult?.min ?? null),
-              },
-              {
-                label: "Max",
-                value: formatNumericValue(numericResult?.max ?? null),
-              },
-              {
-                label: "Mean",
-                value: formatNumericValue(numericResult?.mean ?? null),
-              },
-            ]
-          : []
-      }
-      emptyMessage={
-        constraints
-          ? "No valid numeric responses have been tallied for this role yet."
-          : "This numeric question is missing its configured range."
-      }
-    >
-      {hasResponses && constraints ? (
-        <div className="mt-4 space-y-3">
-          <div className="relative px-1">
-            <div
-              className={cn(
-                "h-2 rounded-full",
-                isGame
-                  ? "bg-white/15"
-                  : "bg-muted dark:bg-[#0bd1a2]/15"
-              )}
-            />
-            <div
-              className="absolute top-1/2 h-4 w-4 -translate-y-1/2 -translate-x-1/2 rounded-full border-2 bg-background shadow-sm"
-              style={{
-                left: `${meanPosition}%`,
-                borderColor: isGame ? "#ffffff" : "#0f172a",
-              }}
-            />
-          </div>
-          <div className="flex items-center justify-between text-xs text-muted-foreground">
-            <span>{formatNumericValue(constraints.minValue)}</span>
-            <span
-              className={cn(
-                "font-medium",
-                isGame ? "text-white" : "text-foreground dark:text-[#0bd1a2]"
-              )}
-            >
-              Mean {formatNumericValue(numericResult?.mean ?? null)}
-            </span>
-            <span>{formatNumericValue(constraints.maxValue)}</span>
-          </div>
-        </div>
-      ) : null}
-    </SummaryCard>
   );
 }
 
@@ -546,206 +109,72 @@ export function LinkedSurveyPanel({
   tallyError,
   isGame = false,
 }: LinkedSurveyPanelProps) {
-  const cardClass = cn(
-    "overflow-hidden p-6",
-    isGame
-      ? "game-detail-card"
-      : "rounded-2xl border border-border bg-card shadow-elevation-2 dark:border-[#0bd1a2] dark:bg-transparent dark:shadow-none"
-  );
-
-  const applicableRoles = getApplicableRoles(survey, tally);
-  const questions = survey?.surveyDetails?.questions ?? [];
-  const defaultQuestionTab = questions[0]?.questionId;
+  const source: SurveyDefinition | null = survey?.bundle?.survey.definition ?? null;
+  const { definition, error: presentationError } = useCip179Presentation(source);
+  const artifact = tally?.artifact ?? null;
+  const cancellation = artifact?.tally.cancelled;
+  const questions = definition?.questions ?? [];
 
   return (
-    <Card className={cardClass}>
+    <Card className={cn("overflow-hidden p-6", isGame ? "game-detail-card" : "border border-border bg-card")}>
       <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0">
-          <h3 className={cn("text-lg font-semibold", isGame && "text-white")}>
-            Linked Survey
-          </h3>
-          {survey?.linked && tally ? (
-            <div className="mt-2">
-              <Badge
-                variant={getTallyPhaseTone(tally.phase)}
-                className="rounded-none"
-              >
-                {getTallyPhaseLabel(tally.phase, tally.finalizationEpoch)}
-              </Badge>
-            </div>
-          ) : null}
-          {survey?.surveyDetails?.title ? (
-            <div className="mt-1">
-              <div className="text-sm font-medium">
-                {survey.surveyDetails.title}
-              </div>
-              {survey.surveyDetails.description ? (
-                <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">
-                  {survey.surveyDetails.description}
-                </p>
-              ) : null}
-            </div>
-          ) : null}
+        <div>
+          <h3 className="text-lg font-semibold">Linked Survey</h3>
+          {definition ? <p className="mt-1 text-sm font-medium">{definition.title}</p> : null}
+          {definition?.description ? <p className="mt-1 text-sm text-muted-foreground">{definition.description}</p> : null}
         </div>
-        {survey?.surveyTxId ? (
-          <Badge variant="outline" className="rounded-none font-mono text-2xs">
-            {survey.surveyTxId.slice(0, 10)}...
+        {survey?.surveyRef ? (
+          <Badge variant="outline" className="font-mono text-2xs">
+            {survey.surveyRef.txId.slice(0, 10)}:{survey.surveyRef.index}
           </Badge>
         ) : null}
       </div>
 
-      {isSurveyLoading ? (
-        <p className="mt-4 text-sm text-muted-foreground">Loading linked survey…</p>
-      ) : surveyError ? (
-        <p className="mt-4 text-sm text-destructive">{surveyError}</p>
-      ) : !survey?.linked ? (
-        <p className="mt-4 text-sm text-muted-foreground">
-          No linked survey is attached to this governance action.
-        </p>
-      ) : !survey.surveyDetails || questions.length === 0 ? (
-        <p className="mt-4 text-sm text-muted-foreground">
-          Linked survey details are not available for display yet.
-        </p>
-      ) : (
+      {isSurveyLoading ? <p className="mt-4 text-sm text-muted-foreground">Loading linked survey...</p>
+      : surveyError ? <p className="mt-4 text-sm text-destructive">{surveyError}</p>
+      : !survey?.linked ? <p className="mt-4 text-sm text-muted-foreground">No linked survey is attached.</p>
+      : !survey.linkValidation.valid ? <p className="mt-4 text-sm text-destructive">{survey.linkValidation.errors.join(" ")}</p>
+      : presentationError && !definition ? <p className="mt-4 text-sm text-destructive">The linked survey cannot be rendered: {presentationError}</p>
+      : !definition ? <p className="mt-4 text-sm text-muted-foreground">The linked survey is still being indexed.</p>
+      : (
         <div className="mt-4 space-y-4">
-          {!survey.linkValidation.valid && survey.linkValidation.errors.length > 0 ? (
-            <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
-              {survey.linkValidation.errors.join(" ")}
-            </div>
+          <div className="flex flex-wrap gap-2">
+            <Badge variant="outline">Ends epoch {definition.endEpoch}</Badge>
+            <Badge variant="outline">{definition.submissionMode.type === "sealed" ? "Sealed" : "Public"}</Badge>
+            <Badge variant={artifact ? "secondary" : "outline"}>
+              {artifact ? "Finalized" : tally?.phase === "unsupported" ? "Results unsupported" : "Results pending"}
+            </Badge>
+          </div>
+          {tallyError || tally?.errors.length ? (
+            <p className="text-sm text-destructive">{tallyError ?? tally?.errors.join(" ")}</p>
           ) : null}
-
-          {!survey.surveyDetailsValidation.valid &&
-          survey.surveyDetailsValidation.errors.length > 0 ? (
-            <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
-              {survey.surveyDetailsValidation.errors.join(" ")}
-            </div>
+          {presentationError ? (
+            <p className="text-sm text-amber-700 dark:text-amber-300">
+              External survey labels could not be verified: {presentationError}
+            </p>
           ) : null}
-
-          {tallyError ? (
-            <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
-              {tallyError}
-            </div>
-          ) : null}
-
-          {tally?.errors?.length ? (
-            <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
-              {tally.errors.join(" ")}
-            </div>
-          ) : null}
-
-          {tally?.warnings?.length ? (
-            <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-700 dark:text-amber-300">
-              {tally.warnings.join(" ")}
-            </div>
-          ) : null}
-
-          <Tabs defaultValue={defaultQuestionTab} className="w-full">
-            <TabsList className="h-auto flex-wrap justify-start gap-2 bg-transparent p-0">
+          {isTallyLoading ? <p className="text-sm text-muted-foreground">Loading results...</p> : null}
+          {cancellation ? (
+            <p className="text-sm text-muted-foreground">
+              This survey was cancelled in transaction {cancellation.txHash.slice(0, 12)}.
+            </p>
+          ) : artifact ? (
+            <Tabs defaultValue="0">
+              <TabsList className="h-auto flex-wrap justify-start">
+                {questions.map((_, index) => <TabsTrigger key={index} value={String(index)}>Question {index + 1}</TabsTrigger>)}
+              </TabsList>
               {questions.map((question, index) => (
-                <TabsTrigger
-                  key={question.questionId}
-                  value={question.questionId}
-                  className={cn(
-                    isGame
-                      ? "game-tab-btn data-[state=active]:game-tab-btn-active text-2xs sm:text-xs"
-                      : "rounded-md border border-border bg-white px-2 py-1 text-2xs font-semibold uppercase tracking-wide text-black shadow-elevation-2 transition-transform transition-shadow duration-normal ease-in-out hover:scale-101 hover:shadow-elevation-3 data-[state=active]:bg-black data-[state=active]:text-white sm:px-3 sm:py-1.5 sm:text-xs dark:rounded-none dark:border-[#0bd1a2] dark:bg-transparent dark:text-[#0bd1a2] dark:shadow-none dark:data-[state=active]:bg-[#0bd1a2] dark:data-[state=active]:text-black dark:hover:bg-[#0bd1a2] dark:hover:text-black whitespace-nowrap btn-neon"
-                  )}
-                >
-                  Question {index + 1}
-                </TabsTrigger>
+                <TabsContent key={index} value={String(index)} className="space-y-3">
+                  <h4 className="font-semibold">{question.prompt}</h4>
+                  <div className="grid gap-3 md:grid-cols-2">
+                    {artifact.tally.perRole.map((role) => (
+                      <RoleResult key={role.role} role={role} question={question} questionIndex={index} />
+                    ))}
+                  </div>
+                </TabsContent>
               ))}
-            </TabsList>
-
-            {questions.map((question) => (
-              <TabsContent
-                key={question.questionId}
-                value={question.questionId}
-                className="mt-4 space-y-4"
-              >
-                <div className="text-base font-semibold">{question.question}</div>
-
-                {question.methodType === BUILTIN_SURVEY_METHODS.singleChoice ||
-                question.methodType === BUILTIN_SURVEY_METHODS.multiSelect ? (
-                  <div
-                    className={cn(
-                      "flex flex-wrap items-start gap-6",
-                      isGame ? "md:gap-4" : "md:gap-6"
-                    )}
-                  >
-                    {applicableRoles.map((role) => (
-                      <ChoiceRoleBlock
-                        key={`${question.questionId}-${role}`}
-                        question={question}
-                        role={role}
-                        weightingMode={getRoleWeightingMode(role, survey, tally)}
-                        result={getMethodResult(role, question.questionId, tally)}
-                      />
-                    ))}
-                  </div>
-                ) : question.methodType === BUILTIN_SURVEY_METHODS.numericRange ? (
-                  <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-                    {applicableRoles.map((role) => (
-                      <NumericRangeRoleCard
-                        key={`${question.questionId}-${role}`}
-                        question={question}
-                        role={role}
-                        weightingMode={getRoleWeightingMode(role, survey, tally)}
-                        result={getMethodResult(role, question.questionId, tally)}
-                        isGame={isGame}
-                      />
-                    ))}
-                  </div>
-                ) : (
-                  <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-                    {applicableRoles.map((role) => {
-                      const customResult = parseCustomMethodResult(
-                        getMethodResult(role, question.questionId, tally)
-                      );
-
-                      const rows = Object.entries(
-                        customResult?.customValueTotals ?? {}
-                      ).map(([value, total]) => ({
-                        label: formatCustomValue(value),
-                        value: formatWeightedValue(
-                          total,
-                          getRoleWeightingMode(role, survey, tally)
-                        ),
-                      }));
-
-                      return (
-                        <SummaryCard
-                          key={`${question.questionId}-${role}`}
-                          role={role}
-                          weightingMode={getRoleWeightingMode(role, survey, tally)}
-                          rows={rows}
-                          emptyMessage="No valid responses have been tallied for this role yet."
-                          isGame={isGame}
-                        />
-                      );
-                    })}
-                  </div>
-                )}
-
-                {isTallyLoading ? (
-                  <p className="text-sm text-muted-foreground">
-                    Loading survey tally…
-                  </p>
-                ) : null}
-
-                {!isTallyLoading && applicableRoles.length === 0 ? (
-                  <p className="text-sm text-muted-foreground">
-                    No survey results are available yet.
-                  </p>
-                ) : null}
-
-                {isCustomSurveyMethod(question.methodType) ? (
-                  <p className="text-xs text-muted-foreground">
-                    This question uses a custom method, so `cgov` displays the tallied values as summary cards instead of donuts.
-                  </p>
-                ) : null}
-              </TabsContent>
-            ))}
-          </Tabs>
+            </Tabs>
+          ) : <p className="text-sm text-muted-foreground">Verified results will appear after the survey closes and finalization completes.</p>}
         </div>
       )}
     </Card>

--- a/src/components/governance/VoteOnProposal.tsx
+++ b/src/components/governance/VoteOnProposal.tsx
@@ -1,6 +1,8 @@
 import { useState, useCallback, useEffect } from "react";
 import { useWallet } from "@meshsdk/react";
 import { MeshTxBuilder, hashDrepAnchor } from "@meshsdk/core";
+import { CredentialType, DRepID } from "@meshsdk/core-cst";
+import { Role, type AnswerItem, type Credential } from "cip-179";
 import { useTranslations } from "next-intl";
 import { useProposalSurvey } from "@/hooks/useGovernanceData";
 import {
@@ -20,7 +22,6 @@ import {
 } from "@/components/ui/dialog";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
-import { Slider } from "@/components/ui/slider";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ConnectWalletButton } from "@/components/wallet";
 import {
@@ -34,18 +35,14 @@ import { useTheme } from "@/lib/theme";
 import { cn } from "@/lib/utils";
 import { wrapRationaleAsJson } from "@/lib/rationaleHelpers";
 import { toCip129DRepId } from "@/lib/drepFormatters";
-import type {
-  ProposalSurveyResponse,
-  SurveyQuestion,
-  SurveyResponsePayload,
-} from "@/types/governance";
 import {
-  BUILTIN_SURVEY_METHODS,
-  buildSurveyResponseMetadata,
-  isCustomSurveyMethod,
-  SUPPORTED_SURVEY_RESPONSE_ROLE,
-  validateSurveyResponse,
+  buildDrepResponse,
+  encodeResponseMetadata,
+  SURVEY_METADATA_LABEL,
+  validateDrepResponse,
 } from "@/lib/surveyMetadata";
+import { Cip179ResponseForm } from "@/components/governance/Cip179ResponseForm";
+import { useCip179Presentation } from "@/hooks/useCip179Presentation";
 
 type VoteChoice = "Yes" | "No" | "Abstain";
 
@@ -75,271 +72,9 @@ interface WalletRoleState {
   detail: string | null;
 }
 
-type SurveyDraftAnswer = {
-  selection?: number[];
-  numericValue?: number;
-  customValue?: string;
-};
-
-async function attachMetadataToVoteBuilder(
-  txBuilder: MeshTxBuilder,
-  metadata: Record<number, unknown>
-) {
-  const builder = txBuilder as MeshTxBuilder & Record<string, unknown>;
-  const [labelKey] = Object.keys(metadata);
-  const label = Number(labelKey);
-  const value = metadata[label];
-
-  const candidates: Array<{ name: string; args: unknown[] }> = [
-    { name: "metadataValue", args: [label, value] },
-    { name: "metadataValue", args: [String(label), value] },
-    { name: "metadataJson", args: [label, value] },
-    { name: "metadataJson", args: [String(label), value] },
-    { name: "metadata", args: [label, value] },
-    { name: "metadata", args: [metadata] },
-    { name: "txMetadata", args: [label, value] },
-    { name: "txMetadata", args: [metadata] },
-    { name: "auxiliaryData", args: [metadata] },
-  ];
-
-  for (const candidate of candidates) {
-    const method = builder[candidate.name];
-    if (typeof method !== "function") continue;
-    try {
-      const result = (method as (...args: unknown[]) => unknown).apply(
-        txBuilder,
-        candidate.args
-      );
-      if (result && typeof (result as Promise<unknown>).then === "function") {
-        await result;
-      }
-      return;
-    } catch {
-      continue;
-    }
-  }
-
-  throw new Error(
-    "This cgov build could not attach CIP-0179 survey metadata to the vote transaction."
-  );
-}
-
-function hasAnySurveyAnswer(answer: SurveyDraftAnswer | undefined): boolean {
-  if (!answer) return false;
-  return (
-    (Array.isArray(answer.selection) && answer.selection.length > 0) ||
-    typeof answer.numericValue === "number" ||
-    (typeof answer.customValue === "string" && answer.customValue.trim() !== "")
-  );
-}
-
-function buildSurveyResponsePayload(
-  survey: ProposalSurveyResponse,
-  answerState: Record<string, SurveyDraftAnswer>
-): SurveyResponsePayload | null {
-  const questions = survey.surveyDetails?.questions ?? [];
-  const answers: SurveyResponsePayload["answers"] = [];
-
-  for (const question of questions) {
-    const answer = answerState[question.questionId];
-    if (!hasAnySurveyAnswer(answer)) continue;
-
-    if (question.methodType === BUILTIN_SURVEY_METHODS.numericRange) {
-      const numericValue = answer?.numericValue;
-      if (!Number.isInteger(numericValue)) {
-        throw new Error(`Question "${question.question}" requires an integer value.`);
-      }
-      answers.push({
-        questionId: question.questionId,
-        numericValue: numericValue as number,
-      });
-      continue;
-    }
-
-    if (Array.isArray(answer?.selection)) {
-      answers.push({
-        questionId: question.questionId,
-        selection: answer.selection,
-      });
-      continue;
-    }
-  }
-
-  if (!answers.length || !survey.surveyTxId) {
-    return null;
-  }
-
-  return {
-    specVersion: "1.0.0",
-    surveyTxId: survey.surveyTxId,
-    responderRole: SUPPORTED_SURVEY_RESPONSE_ROLE,
-    answers,
-  };
-}
-
-function SurveyQuestionInput({
-  question,
-  answer,
-  setAnswer,
-  disabled,
-}: {
-  question: SurveyQuestion;
-  answer?: SurveyDraftAnswer;
-  setAnswer: (next: SurveyDraftAnswer | undefined) => void;
-  disabled: boolean;
-}) {
-  if (question.methodType === BUILTIN_SURVEY_METHODS.singleChoice) {
-    return (
-      <div className="mt-2 space-y-2">
-        <div className="flex flex-wrap gap-2">
-          {(question.options ?? []).map((option, index) => {
-            const isSelected = answer?.selection?.[0] === index;
-            return (
-              <Button
-                key={`${question.questionId}-${option}`}
-                type="button"
-                variant={isSelected ? "secondary" : "outline"}
-                className="h-8 rounded-none text-xs"
-                disabled={disabled}
-                onClick={() =>
-                  setAnswer(
-                    isSelected
-                      ? undefined
-                      : {
-                          selection: [index],
-                        }
-                  )
-                }
-              >
-                {option}
-              </Button>
-            );
-          })}
-        </div>
-        {answer?.selection?.length ? (
-          <Button
-            type="button"
-            variant="ghost"
-            className="h-auto p-0 text-xs text-muted-foreground hover:text-foreground"
-            disabled={disabled}
-            onClick={() => setAnswer(undefined)}
-          >
-            Clear response
-          </Button>
-        ) : null}
-      </div>
-    );
-  }
-
-  if (question.methodType === BUILTIN_SURVEY_METHODS.multiSelect) {
-    const currentSelection = answer?.selection ?? [];
-    const maxSelections = question.maxSelections ?? question.options?.length ?? 0;
-    const selectionLimitReached = currentSelection.length >= maxSelections;
-    return (
-      <div className="mt-2 space-y-2">
-        {maxSelections > 0 ? (
-          <div className="text-xs text-muted-foreground">
-            Select up to {maxSelections} option{maxSelections === 1 ? "" : "s"}.
-          </div>
-        ) : null}
-        {(question.options ?? []).map((option, index) => {
-          const checked = currentSelection.includes(index);
-          return (
-            <label
-              key={`${question.questionId}-${option}`}
-              className={cn(
-                "flex items-center gap-2 text-sm",
-                !checked && selectionLimitReached && "opacity-60"
-              )}
-            >
-              <input
-                type="checkbox"
-                checked={checked}
-                disabled={disabled || (!checked && selectionLimitReached)}
-                onChange={(event) => {
-                  const nextSelection = event.target.checked
-                    ? [...currentSelection, index].sort((left, right) => left - right)
-                    : currentSelection.filter((item) => item !== index);
-                  setAnswer({ selection: nextSelection });
-                }}
-              />
-              <span>{option}</span>
-            </label>
-          );
-        })}
-        {currentSelection.length ? (
-          <Button
-            type="button"
-            variant="ghost"
-            className="h-auto p-0 text-xs text-muted-foreground hover:text-foreground"
-            disabled={disabled}
-            onClick={() => setAnswer(undefined)}
-          >
-            Clear response
-          </Button>
-        ) : null}
-      </div>
-    );
-  }
-
-  if (question.methodType === BUILTIN_SURVEY_METHODS.numericRange) {
-    const constraints = question.numericConstraints;
-    const currentValue = answer?.numericValue;
-    if (!constraints) {
-      return (
-        <div className="mt-2 rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-xs text-amber-700 dark:text-amber-300">
-          This numeric question is missing its constraints, so `cgov` cannot render an input for it.
-        </div>
-      );
-    }
-
-    return (
-      <div className="mt-2 space-y-2.5">
-        <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
-          <span>
-            {constraints.minValue} to {constraints.maxValue}
-            {constraints.step ? `, step ${constraints.step}` : ""}
-          </span>
-          <span className="font-medium text-foreground">
-            {currentValue ?? "No answer selected"}
-          </span>
-        </div>
-        <Slider
-          disabled={disabled}
-          min={constraints.minValue}
-          max={constraints.maxValue}
-          step={constraints.step ?? 1}
-          value={[currentValue ?? constraints.minValue]}
-          onValueChange={(values) => {
-            const nextValue = values[0];
-            if (Number.isInteger(nextValue)) {
-              setAnswer({ numericValue: nextValue });
-            }
-          }}
-        />
-        <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
-          <span>{constraints.minValue}</span>
-          <span>{constraints.maxValue}</span>
-        </div>
-        {currentValue !== undefined ? (
-          <Button
-            type="button"
-            variant="ghost"
-            className="h-auto p-0 text-xs text-muted-foreground hover:text-foreground"
-            disabled={disabled}
-            onClick={() => setAnswer(undefined)}
-          >
-            Clear response
-          </Button>
-        ) : null}
-      </div>
-    );
-  }
-
-  return (
-    <div className="mt-2 rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-xs text-amber-700 dark:text-amber-300">
-      This survey uses a custom method. `cgov` can display the question, but it does not yet render an interactive input for this method.
-    </div>
+function credentialHashBytes(hash: string): Uint8Array {
+  return Uint8Array.from(
+    hash.match(/.{2}/g)?.map((byte) => Number.parseInt(byte, 16)) ?? []
   );
 }
 
@@ -381,7 +116,7 @@ export function VoteOnProposal({
   const [rationaleJsonText, setRationaleJsonText] = useState("");
   const [isUploading, setIsUploading] = useState(false);
   const [isAdvancedOpen, setIsAdvancedOpen] = useState(false);
-  const [surveyAnswers, setSurveyAnswers] = useState<Record<string, SurveyDraftAnswer>>({});
+  const [surveyAnswers, setSurveyAnswers] = useState<AnswerItem[] | null>([]);
   const [voteState, setVoteState] = useState<VoteState>({
     isSubmitting: false,
     isSuccess: false,
@@ -401,25 +136,27 @@ export function VoteOnProposal({
   const linkedSurvey =
     proposalSurvey?.linked &&
     proposalSurvey.linkValidation.valid &&
-    proposalSurvey.surveyDetailsValidation.valid &&
-    proposalSurvey.surveyDetails &&
-    proposalSurvey.surveyTxId
+    proposalSurvey.phase === "open" &&
+    proposalSurvey.bundle &&
+    proposalSurvey.surveyRef
       ? proposalSurvey
       : null;
-  const drepCanRespond = !!linkedSurvey?.surveyDetails?.roleWeighting?.DRep;
-  const surveyQuestionCount = linkedSurvey?.surveyDetails?.questions.length ?? 0;
-  const answeredQuestionCount = linkedSurvey?.surveyDetails?.questions.reduce(
-    (count, question) =>
-      hasAnySurveyAnswer(surveyAnswers[question.questionId]) ? count + 1 : count,
-    0
-  ) ?? 0;
+  const sourceDefinition = linkedSurvey?.bundle?.survey.definition ?? null;
+  const { definition: surveyDefinition, error: surveyPresentationError } =
+    useCip179Presentation(sourceDefinition);
+  const drepCanRespond = !!surveyDefinition &&
+    surveyDefinition.submissionMode.type === "public" &&
+    surveyDefinition.eligibleRoles.includes(Role.DRep);
+  const handleSurveyAnswers = useCallback((answers: AnswerItem[] | null) => {
+    setSurveyAnswers(answers);
+  }, []);
 
   const isVotingOpen = status === "Active";
 
 
   useEffect(() => {
     if (!isModalOpen) {
-      setSurveyAnswers({});
+      setSurveyAnswers([]);
     }
   }, [isModalOpen]);
 
@@ -587,16 +324,34 @@ export function VoteOnProposal({
         verbose: true,
       });
 
-      const surveyResponse = linkedSurvey && drepCanRespond
-        ? buildSurveyResponsePayload(linkedSurvey, surveyAnswers)
-        : null;
+      let surveyResponse = null;
+      if (
+        linkedSurvey &&
+        surveyDefinition &&
+        drepCanRespond &&
+        surveyAnswers &&
+        surveyAnswers.length > 0
+      ) {
+        const drepCredential = DRepID.toCredential(DRepID(drepId));
+        const credential: Credential =
+          drepCredential.type === CredentialType.KeyHash
+            ? { type: "key", keyHash: credentialHashBytes(drepCredential.hash) }
+            : { type: "script", scriptHash: credentialHashBytes(drepCredential.hash) };
+        surveyResponse = buildDrepResponse({
+          survey: linkedSurvey,
+          credential,
+          answers: surveyAnswers,
+        });
+      }
       if (surveyResponse) {
-        const surveyValidationErrors = validateSurveyResponse(
-          linkedSurvey,
+        const surveyValidationErrors = validateDrepResponse(
+          surveyDefinition!,
           surveyResponse
         );
         if (surveyValidationErrors.length > 0) {
-          throw new Error(surveyValidationErrors[0]);
+          throw new Error(
+            `CIP-179 response validation failed: ${surveyValidationErrors[0]}`
+          );
         }
       }
 
@@ -699,9 +454,9 @@ export function VoteOnProposal({
         }
       );
       if (surveyResponse) {
-        await attachMetadataToVoteBuilder(
-          txBuilder,
-          buildSurveyResponseMetadata(surveyResponse)
+        txBuilder.metadataValue(
+          SURVEY_METADATA_LABEL,
+          encodeResponseMetadata(surveyResponse)
         );
       }
 
@@ -781,6 +536,7 @@ export function VoteOnProposal({
     rationaleComment,
     rationaleJsonText,
     linkedSurvey,
+    surveyDefinition,
     drepCanRespond,
     surveyAnswers,
     onVoteSubmitted,
@@ -797,7 +553,7 @@ export function VoteOnProposal({
     setRationaleComment("");
     setRationaleJsonText("");
     setIsAdvancedOpen(false);
-    setSurveyAnswers({});
+    setSurveyAnswers([]);
     setVoteState({
       isSubmitting: false,
       isSuccess: false,
@@ -1098,76 +854,42 @@ export function VoteOnProposal({
                     <div className="rounded-md border border-border/50 p-3 text-sm text-muted-foreground">
                       The linked survey could not be loaded. Your governance vote can still be submitted without a survey response.
                     </div>
-                  ) : linkedSurvey?.surveyDetails ? (
+                  ) : surveyPresentationError && !surveyDefinition ? (
+                    <div className="rounded-md border border-border/50 p-3 text-sm text-muted-foreground">
+                      The linked survey cannot be rendered: {surveyPresentationError}
+                    </div>
+                  ) : surveyDefinition ? (
                     <div className="space-y-3 rounded-md border border-border/50 p-4">
                       <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
                         <div className="min-w-0">
                           <div className="text-sm font-semibold">
-                            {linkedSurvey.surveyDetails.title}
+                            {surveyDefinition.title}
                           </div>
                           <p className="mt-1 text-xs text-muted-foreground">
-                            Optional survey response. Ends at epoch {linkedSurvey.surveyDetails.endEpoch}.
+                            Optional CIP-179 response. Ends at epoch {surveyDefinition.endEpoch}.
                           </p>
                         </div>
-                        {drepCanRespond ? (
-                          <Badge variant="outline" className="w-fit text-xs">
-                            Answered {answeredQuestionCount} of {surveyQuestionCount}
-                          </Badge>
-                        ) : null}
+                        <Badge variant="outline" className="w-fit text-xs">Version 5</Badge>
                       </div>
-                      {!drepCanRespond ? (
+                      {surveyPresentationError ? (
+                        <div className="text-xs text-amber-700 dark:text-amber-300">
+                          External labels could not be verified: {surveyPresentationError}
+                        </div>
+                      ) : null}
+                      {surveyDefinition.submissionMode.type === "sealed" ? (
+                        <div className="text-xs text-muted-foreground">
+                          This survey uses sealed responses. This CGov release displays sealed surveys but does not submit encrypted answers.
+                        </div>
+                      ) : !drepCanRespond ? (
                         <div className="text-xs text-muted-foreground">
                           This linked survey does not accept DRep responses, so only the governance vote will be submitted.
                         </div>
                       ) : (
-                        <div className="space-y-2">
-                          {linkedSurvey.surveyDetails.questions.map((question, index) => (
-                            <div
-                              key={question.questionId}
-                              className="rounded-md border border-border/50 bg-background/40 p-3"
-                            >
-                              <div className="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between">
-                                <div className="min-w-0">
-                                  <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                                    Question {index + 1}
-                                  </div>
-                                  <div className="mt-1 text-sm font-medium">
-                                    {question.question}
-                                  </div>
-                                </div>
-                                {!isCustomSurveyMethod(question.methodType) ? (
-                                  <div className="text-xs text-muted-foreground">
-                                    {question.methodType}
-                                  </div>
-                                ) : null}
-                              </div>
-                              {isCustomSurveyMethod(question.methodType) ? (
-                                <div className="mt-2 rounded-md border border-amber-500/40 bg-amber-500/10 p-2.5 text-xs text-amber-700 dark:text-amber-300">
-                                  This survey question uses a custom method. `cgov` will not submit a response for this question until a custom renderer is implemented.
-                                </div>
-                              ) : (
-                                <SurveyQuestionInput
-                                  question={question}
-                                  answer={surveyAnswers[question.questionId]}
-                                  disabled={voteState.isSubmitting}
-                                  setAnswer={(next) => {
-                                    setSurveyAnswers((current) => {
-                                      if (!next || !hasAnySurveyAnswer(next)) {
-                                        const nextState = { ...current };
-                                        delete nextState[question.questionId];
-                                        return nextState;
-                                      }
-                                      return {
-                                        ...current,
-                                        [question.questionId]: next,
-                                      };
-                                    });
-                                  }}
-                                />
-                              )}
-                            </div>
-                          ))}
-                        </div>
+                        <Cip179ResponseForm
+                          definition={surveyDefinition}
+                          disabled={voteState.isSubmitting}
+                          onAnswersChange={handleSurveyAnswers}
+                        />
                       )}
                     </div>
                   ) : null}

--- a/src/hooks/useCip179Presentation.ts
+++ b/src/hooks/useCip179Presentation.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+import type { SurveyDefinition } from "cip-179";
+import {
+  applyPresentation,
+  fetchAnchorJson,
+  getRenderabilityProblem,
+} from "@/lib/cip179Content";
+
+export function useCip179Presentation(source: SurveyDefinition | null) {
+  const [definition, setDefinition] = useState(source);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    const renderabilityProblem = source
+      ? getRenderabilityProblem(source)
+      : null;
+    setDefinition(renderabilityProblem ? null : source);
+    setError(renderabilityProblem);
+    if (!source?.contentAnchor || renderabilityProblem) {
+      return () => { active = false; };
+    }
+    void fetchAnchorJson(source.contentAnchor)
+      .then((value) => {
+        if (active) setDefinition(applyPresentation(source, value));
+      })
+      .catch((reason) => {
+        if (active) setError(reason instanceof Error ? reason.message : String(reason));
+      });
+    return () => { active = false; };
+  }, [source]);
+
+  return { definition, error };
+}

--- a/src/hooks/useGovernanceData.ts
+++ b/src/hooks/useGovernanceData.ts
@@ -533,9 +533,13 @@ export function useProposalSurvey(
       revalidateOnMount: true,
     }
   );
+  const survey = useMemo(
+    () => normalizeProposalSurveyResponse(data),
+    [data]
+  );
 
   return {
-    survey: normalizeProposalSurveyResponse(data) ?? null,
+    survey,
     isLoading: !fallbackData && isLoading,
     error: error?.message ?? null,
     refresh: mutate,

--- a/src/lib/cip179Content.ts
+++ b/src/lib/cip179Content.ts
@@ -1,0 +1,136 @@
+import { blake2b } from "@noble/hashes/blake2.js";
+import type {
+  ContentAnchor,
+  OptionsOrCount,
+  Question,
+  RatingScale,
+  SurveyDefinition,
+} from "cip-179";
+
+const IPFS_GATEWAYS = [
+  "https://ipfs.io/ipfs/",
+  "https://dweb.link/ipfs/",
+  "https://gateway.pinata.cloud/ipfs/",
+];
+
+export const MAX_RENDERED_SURVEY_ITEMS = 100;
+
+export function getRenderabilityProblem(
+  definition: SurveyDefinition
+): string | null {
+  if (definition.questions.length > MAX_RENDERED_SURVEY_ITEMS) {
+    return `Survey has more than ${MAX_RENDERED_SURVEY_ITEMS} questions.`;
+  }
+  const optionsIndex = definition.questions.findIndex(
+    (question) =>
+      "options" in question &&
+      (question.options.type === "options"
+        ? question.options.labels.length
+        : question.options.count) > MAX_RENDERED_SURVEY_ITEMS
+  );
+  if (optionsIndex >= 0) {
+    return `Question ${optionsIndex + 1} has more than ${MAX_RENDERED_SURVEY_ITEMS} options.`;
+  }
+  const ratingIndex = definition.questions.findIndex(
+    (question) =>
+      question.type === "rating" &&
+      question.scale.type !== "numeric" &&
+      (question.scale.type === "labels"
+        ? question.scale.labels.length
+        : question.scale.count) > MAX_RENDERED_SURVEY_ITEMS
+  );
+  return ratingIndex >= 0
+    ? `Question ${ratingIndex + 1} has more than ${MAX_RENDERED_SURVEY_ITEMS} rating levels.`
+    : null;
+}
+
+function equalBytes(left: Uint8Array, right: Uint8Array): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+async function verifiedBytes(url: string, expected: Uint8Array): Promise<Uint8Array> {
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  if (!equalBytes(blake2b(bytes, { dkLen: 32 }), expected)) {
+    throw new Error("Content hash does not match the on-chain anchor.");
+  }
+  return bytes;
+}
+
+export async function fetchAnchorJson(anchor: ContentAnchor): Promise<unknown> {
+  let bytes: Uint8Array | null = null;
+  if (anchor.uri.startsWith("https://")) {
+    bytes = await verifiedBytes(anchor.uri, anchor.hash);
+  } else if (anchor.uri.startsWith("ipfs://")) {
+    for (const gateway of IPFS_GATEWAYS) {
+      try {
+        bytes = await verifiedBytes(gateway + anchor.uri.slice(7), anchor.hash);
+        break;
+      } catch {
+        // Try the next public gateway.
+      }
+    }
+  } else {
+    throw new Error("Only HTTPS and IPFS content anchors are supported.");
+  }
+  if (!bytes) throw new Error("No IPFS gateway returned verified content.");
+  return JSON.parse(new TextDecoder().decode(bytes));
+}
+
+function strings(value: unknown): string[] | undefined {
+  return Array.isArray(value) && value.every((item) => typeof item === "string")
+    ? value
+    : undefined;
+}
+
+function fillOptions(options: OptionsOrCount, labels: string[] | undefined): OptionsOrCount {
+  return options.type === "count" && labels?.length === options.count
+    ? { type: "options", labels }
+    : options;
+}
+
+function fillScale(scale: RatingScale, labels: string[] | undefined): RatingScale {
+  return scale.type === "count" && labels?.length === scale.count
+    ? { type: "labels", labels }
+    : scale;
+}
+
+export function applyPresentation(definition: SurveyDefinition, value: unknown): SurveyDefinition {
+  if (!value || typeof value !== "object") throw new Error("Presentation is not an object.");
+  const document = value as Record<string, unknown>;
+  if (document.kind !== "cardano-survey-presentation" || document.specVersion !== 5) {
+    throw new Error("Presentation is not a CIP-179 v5 presentation document.");
+  }
+  const presentations = Array.isArray(document.questions) ? document.questions : [];
+  const questions = definition.questions.map((question, index): Question => {
+    const raw = presentations[index];
+    const item = raw && typeof raw === "object" ? raw as Record<string, unknown> : {};
+    const prompt = question.prompt.trim() === "" && typeof item.prompt === "string"
+      ? item.prompt
+      : question.prompt;
+    if (question.type === "custom" || question.type === "numericRange") return { ...question, prompt };
+    if (question.type === "rating") {
+      return {
+        ...question,
+        prompt,
+        options: fillOptions(question.options, strings(item.options)),
+        scale: fillScale(question.scale, strings(item.ratingLabels)),
+      };
+    }
+    return { ...question, prompt, options: fillOptions(question.options, strings(item.options)) };
+  });
+  return {
+    ...definition,
+    title: definition.title.trim() === "" && typeof document.title === "string" ? document.title : definition.title,
+    description: definition.description.trim() === "" && typeof document.description === "string" ? document.description : definition.description,
+    questions,
+  };
+}
+
+export function schemaAcceptsText(value: unknown): boolean {
+  if (!value || typeof value !== "object") return false;
+  const schema = value as Record<string, unknown>;
+  return schema.type === "string" ||
+    (Array.isArray(schema.type) && schema.type.includes("string"));
+}

--- a/src/lib/serverFetch.ts
+++ b/src/lib/serverFetch.ts
@@ -6,15 +6,12 @@
 import type {
   GovernanceAction,
   GovernanceActionDetail,
-  ProposalSurveyResponse,
-  ProposalSurveyTallyResponse,
   VoteRecord,
   ProposalReferenceObject,
   OverviewSummary,
   NCLYearData,
   NCLDisplayData,
 } from "@/types/governance";
-import { normalizeProposalSurveyResponse } from "@/lib/surveyMetadata";
 import { correctedWithdrawalAmount } from "@/lib/withdrawalAmountOverrides";
 
 const BACKEND_API_URL = process.env.BACKEND_API_URL || "http://localhost:3001";
@@ -301,33 +298,6 @@ export async function fetchGovernanceActionDetailServer(
     return sanitizeForJson(transformed);
   } catch (error) {
     console.error("Failed to fetch proposal detail server-side:", error);
-    return null;
-  }
-}
-
-export async function fetchProposalSurveyServer(
-  proposalId: string
-): Promise<ProposalSurveyResponse | null> {
-  try {
-    const survey = await fetchBackend<ProposalSurveyResponse>(
-      `/proposal/${encodeURIComponent(proposalId)}/survey`
-    );
-    return normalizeProposalSurveyResponse(survey);
-  } catch (error) {
-    console.error("Failed to fetch proposal survey server-side:", error);
-    return null;
-  }
-}
-
-export async function fetchProposalSurveyTallyServer(
-  proposalId: string
-): Promise<ProposalSurveyTallyResponse | null> {
-  try {
-    return await fetchBackend<ProposalSurveyTallyResponse>(
-      `/proposal/${encodeURIComponent(proposalId)}/survey-tally`
-    );
-  } catch (error) {
-    console.error("Failed to fetch proposal survey tally server-side:", error);
     return null;
   }
 }

--- a/src/lib/surveyMetadata.test.mts
+++ b/src/lib/surveyMetadata.test.mts
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import { webcrypto } from "node:crypto";
+import test from "node:test";
+import { Role, decodePayload, type SurveyDefinition } from "cip-179";
+import {
+  buildDrepResponse,
+  encodeResponseMetadata,
+  validateDrepResponse,
+} from "./surveyMetadata";
+import {
+  applyPresentation,
+  getRenderabilityProblem,
+} from "./cip179Content";
+import { answerFor } from "../components/governance/Cip179ResponseForm";
+
+const definition: SurveyDefinition = {
+  specVersion: 5,
+  owner: { type: "key", keyHash: new Uint8Array(28) },
+  title: "Public survey",
+  description: "CIP-179 v5",
+  eligibleRoles: [Role.DRep],
+  endEpoch: 600,
+  submissionMode: { type: "public" },
+  questions: [
+    {
+      type: "singleChoice",
+      prompt: "Choose",
+      options: { type: "options", labels: ["A", "B"] },
+      required: true,
+    },
+  ],
+};
+
+test("builds metadata that round-trips through the reusable codec", async () => {
+  const survey = {
+    linked: true,
+    surveyRef: { txId: "ab".repeat(32), index: 2 },
+    linkValidation: { valid: true, errors: [], linkedActions: [] },
+    phase: "open" as const,
+    bundle: {
+      survey: {
+        txHash: "ab".repeat(32),
+        slot: 1,
+        epochNo: 1,
+        ref: { txId: new Uint8Array(32).fill(0xab), index: 2 },
+        definition,
+      },
+      responses: [],
+      cancellations: [],
+      tip: { epoch: 1, slot: 1, time: 1, epochSlot: 1, govActionLifetime: 6 },
+    },
+  };
+  const response = buildDrepResponse({
+    survey,
+    credential: { type: "key", keyHash: new Uint8Array(28).fill(1) },
+    answers: [{ type: "singleChoice", questionIndex: 0, optionIndex: 1 }],
+  });
+  assert.deepEqual(validateDrepResponse(definition, response), []);
+  assert.deepEqual(decodePayload(encodeResponseMetadata(response)), {
+    type: "responses",
+    responses: [response],
+  });
+
+  Object.defineProperty(globalThis, "crypto", { value: webcrypto });
+  const { MeshTxBuilder } = await import("@meshsdk/core");
+  const builder = new MeshTxBuilder();
+  builder.metadataValue(17, encodeResponseMetadata(response));
+  const label17 = builder.meshTxBuilderBody.metadata.get(BigInt(17));
+  assert.equal(Array.isArray(label17), true);
+  assert.equal(Array.isArray((label17 as unknown[])[1]), true);
+  const responseMap = ((label17 as unknown[])[1] as unknown[])[0];
+  assert.equal(responseMap instanceof Map, true);
+  assert.deepEqual(
+    [...(responseMap as Map<unknown, unknown>).keys()],
+    [BigInt(0), BigInt(1), BigInt(2), BigInt(3), BigInt(4)]
+  );
+});
+
+test("applies only matching external presentation fields", () => {
+  const external: SurveyDefinition = {
+    ...definition,
+    title: "",
+    questions: [{
+      type: "singleChoice",
+      prompt: "",
+      options: { type: "count", count: 2 },
+    }],
+  };
+  const enriched = applyPresentation(external, {
+    specVersion: 5,
+    kind: "cardano-survey-presentation",
+    title: "External title",
+    description: "External description",
+    questions: [{ prompt: "External prompt", options: ["One", "Two"] }],
+  });
+  assert.equal(enriched.title, "External title");
+  assert.equal(enriched.questions[0].prompt, "External prompt");
+  assert.deepEqual(
+    enriched.questions[0].type === "singleChoice" ? enriched.questions[0].options : null,
+    { type: "options", labels: ["One", "Two"] }
+  );
+});
+
+test("rejects definitions that would create unbounded response controls", () => {
+  assert.match(
+    getRenderabilityProblem({
+      ...definition,
+      questions: [{
+        type: "singleChoice",
+        prompt: "Choose",
+        options: { type: "count", count: 101 },
+      }],
+      contentAnchor: {
+        uri: "https://example.com/presentation.json",
+        hash: new Uint8Array(32),
+      },
+    }) ?? "",
+    /more than 100 options/
+  );
+});
+
+test("validates rating grids and points allocations without lossy parsing", () => {
+  const rating = {
+    type: "rating" as const,
+    prompt: "Rate",
+    options: { type: "options" as const, labels: ["A"] },
+    scale: { type: "numeric" as const, constraints: { min: 100n, max: 1000n, step: 100n } },
+    requireAll: false,
+  };
+  assert.deepEqual(answerFor(rating, 0, { type: "rating", ratings: ["1000"] }), {
+    type: "rating",
+    questionIndex: 0,
+    ratings: [{ optionIndex: 0, rating: 1000n }],
+  });
+  assert.equal(answerFor(rating, 0, { type: "rating", ratings: ["150"] }), false);
+
+  const points = {
+    type: "pointsAllocation" as const,
+    prompt: "Allocate",
+    options: { type: "options" as const, labels: ["A", "B"] },
+    budget: 10,
+  };
+  assert.equal(answerFor(points, 0, { type: "pointsAllocation", points: ["1.5", "8.5"] }), false);
+  assert.deepEqual(answerFor(points, 0, { type: "pointsAllocation", points: ["3", "7"] }), {
+    type: "pointsAllocation",
+    questionIndex: 0,
+    allocations: [{ optionIndex: 0, points: 3 }, { optionIndex: 1, points: 7 }],
+  });
+});

--- a/src/lib/surveyMetadata.ts
+++ b/src/lib/surveyMetadata.ts
@@ -1,472 +1,56 @@
+import {
+  Role,
+  encodePayload,
+  validateDefinition,
+  validateResponse,
+  type AnswerItem,
+  type Credential,
+  type Metadatum,
+  type SurveyDefinition,
+  type SurveyResponse,
+} from "cip-179";
+import { fromJsonSafe } from "cip-179/tally";
 import type {
   ProposalSurveyResponse,
-  ResponderRole,
-  SurveyDetails,
-  SurveyQuestion,
-  SurveyResponseAnswer,
-  SurveyResponsePayload,
 } from "@/types/governance";
 
-export const SURVEY_SPEC_VERSION = "1.0.0";
 export const SURVEY_METADATA_LABEL = 17;
-export const SURVEY_LINK_KIND = "cardano-governance-survey-link";
-export const BUILTIN_SURVEY_METHODS = {
-  singleChoice: "urn:cardano:poll-method:single-choice:v1",
-  multiSelect: "urn:cardano:poll-method:multi-select:v1",
-  numericRange: "urn:cardano:poll-method:numeric-range:v1",
-} as const;
-
-export const SUPPORTED_SURVEY_METHODS = new Set<string>(
-  Object.values(BUILTIN_SURVEY_METHODS)
-);
-export const SUPPORTED_SURVEY_RESPONSE_ROLE: ResponderRole = "DRep";
-
-type SurveyEnvelope = {
-  [SURVEY_METADATA_LABEL]?: {
-    msg?: unknown;
-    surveyDetails?: unknown;
-    surveyResponse?: unknown;
-  };
-};
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function isRole(value: unknown): value is ResponderRole {
-  return value === "DRep" || value === "SPO" || value === "CC" || value === "Stakeholder";
-}
-
-export function isBuiltInSurveyMethod(methodType: string): boolean {
-  return SUPPORTED_SURVEY_METHODS.has(methodType);
-}
-
-export function isCustomSurveyMethod(methodType: string): boolean {
-  return !isBuiltInSurveyMethod(methodType);
-}
-
-export function parseSurveyLinkAnchor(
-  anchor: unknown
-): { kind?: string; specVersion?: string; surveyTxId?: string } | null {
-  if (!isRecord(anchor)) return null;
-  return {
-    kind: typeof anchor.kind === "string" ? anchor.kind : undefined,
-    specVersion:
-      typeof anchor.specVersion === "string" ? anchor.specVersion : undefined,
-    surveyTxId: typeof anchor.surveyTxId === "string" ? anchor.surveyTxId : undefined,
-  };
-}
-
-function normalizeMetadataText(value: unknown): string | null {
-  if (typeof value === "string") {
-    return value;
-  }
-
-  if (Array.isArray(value) && value.every((item) => typeof item === "string")) {
-    return value.join("");
-  }
-
-  return null;
-}
-
-function normalizeSurveyQuestion(question: unknown): SurveyQuestion | null {
-  if (!isRecord(question)) return null;
-
-  const questionId = normalizeMetadataText(question.questionId);
-  const prompt = normalizeMetadataText(question.question);
-  const methodType = normalizeMetadataText(question.methodType);
-  if (!questionId || !prompt || !methodType) {
-    return null;
-  }
-
-  let options: string[] | undefined;
-  if (question.options !== undefined) {
-    if (!Array.isArray(question.options)) return null;
-    options = [];
-    for (const option of question.options) {
-      const normalizedOption = normalizeMetadataText(option);
-      if (normalizedOption === null) return null;
-      options.push(normalizedOption);
-    }
-  }
-
-  let numericConstraints: SurveyQuestion["numericConstraints"] | undefined;
-  if (question.numericConstraints !== undefined) {
-    if (!isRecord(question.numericConstraints)) return null;
-    const minValue = question.numericConstraints.minValue;
-    const maxValue = question.numericConstraints.maxValue;
-    const step = question.numericConstraints.step;
-    if (
-      typeof minValue !== "number" ||
-      typeof maxValue !== "number" ||
-      !Number.isInteger(minValue) ||
-      !Number.isInteger(maxValue) ||
-      (step !== undefined &&
-        (typeof step !== "number" || !Number.isInteger(step)))
-    ) {
-      return null;
-    }
-
-    numericConstraints = {
-      minValue: minValue as number,
-      maxValue: maxValue as number,
-      ...(step !== undefined ? { step: step as number } : {}),
-    };
-  }
-
-  const methodSchemaUri = normalizeMetadataText(question.methodSchemaUri);
-  const methodSchemaHash = normalizeMetadataText(question.methodSchemaHash);
-
-  return {
-    questionId,
-    question: prompt,
-    methodType,
-    ...(options !== undefined ? { options } : {}),
-    ...(Number.isInteger(question.maxSelections)
-      ? { maxSelections: question.maxSelections as number }
-      : {}),
-    ...(numericConstraints ? { numericConstraints } : {}),
-    ...(methodSchemaUri ? { methodSchemaUri } : {}),
-    ...(methodSchemaHash ? { methodSchemaHash } : {}),
-  };
-}
-
-export function normalizeSurveyDetails(
-  value: unknown
-): SurveyDetails | null {
-  if (!isRecord(value)) return null;
-
-  const specVersion = normalizeMetadataText(value.specVersion);
-  const title = normalizeMetadataText(value.title);
-  const description = normalizeMetadataText(value.description);
-  if (!specVersion || !title || !description) {
-    return null;
-  }
-
-  if (!Array.isArray(value.questions)) return null;
-  const questions: SurveyQuestion[] = [];
-  for (const question of value.questions) {
-    const normalizedQuestion = normalizeSurveyQuestion(question);
-    if (!normalizedQuestion) return null;
-    questions.push(normalizedQuestion);
-  }
-
-  if (!isRecord(value.roleWeighting)) return null;
-  const roleWeighting: SurveyDetails["roleWeighting"] = {};
-  for (const [role, weightingMode] of Object.entries(value.roleWeighting)) {
-    const normalizedWeightingMode = normalizeMetadataText(weightingMode);
-    if (
-      isRole(role) &&
-      (normalizedWeightingMode === "CredentialBased" ||
-        normalizedWeightingMode === "StakeBased" ||
-        normalizedWeightingMode === "PledgeBased")
-    ) {
-      roleWeighting[role] = normalizedWeightingMode;
-    } else {
-      return null;
-    }
-  }
-
-  const endEpoch = value.endEpoch;
-  if (
-    typeof endEpoch !== "number" ||
-    !Number.isInteger(endEpoch) ||
-    endEpoch < 0
-  ) {
-    return null;
-  }
-
-  return {
-    specVersion,
-    title,
-    description,
-    questions,
-    roleWeighting,
-    endEpoch: endEpoch as number,
-  };
-}
 
 export function normalizeProposalSurveyResponse(
-  survey: ProposalSurveyResponse | null | undefined
+  value: ProposalSurveyResponse | null | undefined
 ): ProposalSurveyResponse | null {
-  if (!survey) return null;
+  if (!value) return null;
   return {
-    ...survey,
-    surveyDetails: normalizeSurveyDetails(survey.surveyDetails),
+    ...value,
+    bundle: value.bundle ? (fromJsonSafe(value.bundle) as ProposalSurveyResponse["bundle"]) : null,
   };
 }
 
-export function extractSurveyDetailsEnvelope(metadata: unknown): SurveyDetails | null {
-  if (!isRecord(metadata)) return null;
-  const envelope = metadata as SurveyEnvelope;
-  const details = envelope[SURVEY_METADATA_LABEL]?.surveyDetails;
-  return normalizeSurveyDetails(details);
-}
-
-export function extractSurveyResponseEnvelope(
-  metadata: unknown
-): SurveyResponsePayload | null {
-  if (!isRecord(metadata)) return null;
-  const envelope = metadata as SurveyEnvelope;
-  const response = envelope[SURVEY_METADATA_LABEL]?.surveyResponse;
-  return isSurveyResponsePayload(response) ? response : null;
-}
-
-function isSurveyResponseAnswer(value: unknown): value is SurveyResponseAnswer {
-  if (!isRecord(value) || typeof value.questionId !== "string") return false;
-  const keys = ["selection", "numericValue", "customValue"].filter(
-    (key) => value[key] !== undefined
-  );
-  if (keys.length !== 1) return false;
-
-  if (value.selection !== undefined) {
-    return (
-      Array.isArray(value.selection) &&
-      value.selection.every(
-        (item) => Number.isInteger(item) && (item as number) >= 0
-      )
-    );
-  }
-
-  if (value.numericValue !== undefined) {
-    return Number.isInteger(value.numericValue);
-  }
-
-  return true;
-}
-
-function isSurveyResponsePayload(value: unknown): value is SurveyResponsePayload {
-  if (!isRecord(value)) return false;
-  return (
-    value.specVersion === SURVEY_SPEC_VERSION &&
-    typeof value.surveyTxId === "string" &&
-    isRole(value.responderRole) &&
-    Array.isArray(value.answers) &&
-    value.answers.every(isSurveyResponseAnswer)
-  );
-}
-
-function validateSingleChoiceAnswer(
-  question: SurveyQuestion,
-  answer: SurveyResponseAnswer
-): string | null {
-  if (!Array.isArray(answer.selection)) {
-    return `Question "${question.question}" requires a single option selection.`;
-  }
-  if (answer.selection.length !== 1) {
-    return `Question "${question.question}" requires exactly one selected option.`;
-  }
-  const optionCount = question.options?.length ?? 0;
-  const index = answer.selection[0];
-  if (index < 0 || index >= optionCount) {
-    return `Question "${question.question}" has an out-of-range answer index.`;
-  }
-  return null;
-}
-
-function validateMultiSelectAnswer(
-  question: SurveyQuestion,
-  answer: SurveyResponseAnswer
-): string | null {
-  if (!Array.isArray(answer.selection)) {
-    return `Question "${question.question}" requires an option selection array.`;
-  }
-  const optionCount = question.options?.length ?? 0;
-  if (answer.selection.some((index) => index < 0 || index >= optionCount)) {
-    return `Question "${question.question}" has an out-of-range answer index.`;
-  }
-  const limit = question.maxSelections ?? question.options?.length ?? 0;
-  if (answer.selection.length > limit) {
-    return `Question "${question.question}" exceeds the maximum number of selections.`;
-  }
-  return null;
-}
-
-function validateNumericRangeAnswer(
-  question: SurveyQuestion,
-  answer: SurveyResponseAnswer
-): string | null {
-  const numericValue = answer.numericValue;
-  if (typeof numericValue !== "number" || !Number.isInteger(numericValue)) {
-    return `Question "${question.question}" requires an integer response.`;
-  }
-  const constraints = question.numericConstraints;
-  if (!constraints) {
-    return `Question "${question.question}" is missing numeric constraints.`;
-  }
-  if (
-    numericValue < constraints.minValue ||
-    numericValue > constraints.maxValue
-  ) {
-    return `Question "${question.question}" is outside the permitted numeric range.`;
-  }
-  if (
-    constraints.step &&
-    ((numericValue - constraints.minValue) % constraints.step !== 0)
-  ) {
-    return `Question "${question.question}" does not match the required numeric step.`;
-  }
-  return null;
-}
-
-export function validateSurveyDetails(details: SurveyDetails | null | undefined): string[] {
-  const normalizedDetails = normalizeSurveyDetails(details);
-  if (!normalizedDetails) {
-    return ["Survey details payload does not match the pinned CIP-0179 shape."];
-  }
-
-  const errors: string[] = [];
-  const questionIds = new Set<string>();
-  for (const question of normalizedDetails.questions) {
-    if (questionIds.has(question.questionId)) {
-      errors.push(`Question id "${question.questionId}" is duplicated.`);
-    }
-    questionIds.add(question.questionId);
-
-    if (question.methodType === BUILTIN_SURVEY_METHODS.singleChoice) {
-      if (!Array.isArray(question.options) || question.options.length < 2) {
-        errors.push(`Question "${question.question}" must provide at least two options.`);
-      }
-      if (question.maxSelections !== undefined && question.maxSelections !== 1) {
-        errors.push(
-          `Question "${question.question}" must not set maxSelections above 1.`
-        );
-      }
-    } else if (question.methodType === BUILTIN_SURVEY_METHODS.multiSelect) {
-      if (!Array.isArray(question.options) || question.options.length < 2) {
-        errors.push(`Question "${question.question}" must provide at least two options.`);
-      }
-      if (
-        !Number.isInteger(question.maxSelections) ||
-        (question.maxSelections ?? 0) <= 0 ||
-        (question.options && (question.maxSelections ?? 0) > question.options.length)
-      ) {
-        errors.push(
-          `Question "${question.question}" requires maxSelections between 1 and the number of options.`
-        );
-      }
-    } else if (question.methodType === BUILTIN_SURVEY_METHODS.numericRange) {
-      if (!question.numericConstraints) {
-        errors.push(`Question "${question.question}" requires numeric constraints.`);
-      } else if (
-        question.numericConstraints.step !== undefined &&
-        question.numericConstraints.step <= 0
-      ) {
-        errors.push(`Question "${question.question}" requires a positive numeric step.`);
-      }
-    } else if (!question.methodSchemaUri || !question.methodSchemaHash) {
-      errors.push(
-        `Custom question "${question.question}" must define methodSchemaUri and methodSchemaHash.`
-      );
-    }
-  }
-
-  return errors;
-}
-
-export function validateSurveyResponse(
-  survey: ProposalSurveyResponse | null | undefined,
-  response: SurveyResponsePayload
-): string[] {
-  const errors: string[] = [];
-
-  if (!isSurveyResponsePayload(response)) {
-    return ["Survey response payload does not match the pinned CIP-0179 shape."];
-  }
-
-  const surveyDetails = normalizeSurveyDetails(survey?.surveyDetails);
-  if (!surveyDetails) {
-    errors.push("Linked survey details are unavailable.");
-    return errors;
-  }
-
-  const surveyErrors = validateSurveyDetails(surveyDetails);
-  if (surveyErrors.length) {
-    return surveyErrors;
-  }
-
-  if (response.specVersion !== SURVEY_SPEC_VERSION) {
-    errors.push("Survey response uses an unsupported spec version.");
-  }
-
-  if (survey?.surveyTxId && response.surveyTxId !== survey.surveyTxId) {
-    errors.push("Survey response does not target the linked survey transaction.");
-  }
-
-  if (
-    survey?.linkValidation.linkedRoleWeighting &&
-    !survey.linkValidation.linkedRoleWeighting[response.responderRole]
-  ) {
-    errors.push(
-      `The linked survey does not accept responses from the ${response.responderRole} role.`
-    );
-  } else if (!surveyDetails.roleWeighting[response.responderRole]) {
-    errors.push(
-      `The linked survey does not define weighting for the ${response.responderRole} role.`
-    );
-  }
-
-  const seenQuestionIds = new Set<string>();
-  const questionMap = new Map<string, SurveyQuestion>(
-    surveyDetails.questions.map((question) => [question.questionId, question])
-  );
-
-  for (const answer of response.answers) {
-    if (seenQuestionIds.has(answer.questionId)) {
-      errors.push(`Question "${answer.questionId}" appears more than once in the response.`);
-      continue;
-    }
-    seenQuestionIds.add(answer.questionId);
-
-    const question = questionMap.get(answer.questionId);
-    if (!question) {
-      errors.push(`Question "${answer.questionId}" does not exist in the linked survey.`);
-      continue;
-    }
-
-    const answerRecord = answer as unknown as Record<string, unknown>;
-    const answerKeys = ["selection", "numericValue", "customValue"].filter(
-      (key) => answerRecord[key] !== undefined
-    );
-    if (answerKeys.length !== 1) {
-      errors.push(`Question "${question.question}" must use exactly one answer value.`);
-      continue;
-    }
-
-    if (question.methodType === BUILTIN_SURVEY_METHODS.singleChoice) {
-      const error = validateSingleChoiceAnswer(question, answer);
-      if (error) errors.push(error);
-      continue;
-    }
-
-    if (question.methodType === BUILTIN_SURVEY_METHODS.multiSelect) {
-      const error = validateMultiSelectAnswer(question, answer);
-      if (error) errors.push(error);
-      continue;
-    }
-
-    if (question.methodType === BUILTIN_SURVEY_METHODS.numericRange) {
-      const error = validateNumericRangeAnswer(question, answer);
-      if (error) errors.push(error);
-      continue;
-    }
-
-    if (answer.customValue === undefined) {
-      errors.push(
-        `Custom question "${question.question}" requires a customValue response.`
-      );
-    }
-  }
-
-  return errors;
-}
-
-export function buildSurveyResponseMetadata(
-  response: SurveyResponsePayload
-): Record<number, { surveyResponse: SurveyResponsePayload }> {
+export function buildDrepResponse(params: {
+  survey: ProposalSurveyResponse;
+  credential: Credential;
+  answers: AnswerItem[];
+}): SurveyResponse {
+  if (!params.survey.surveyRef) throw new Error("Linked survey reference is unavailable.");
   return {
-    [SURVEY_METADATA_LABEL]: {
-      surveyResponse: response,
+    specVersion: 5,
+    surveyRef: {
+      txId: params.survey.bundle!.survey.ref.txId,
+      index: params.survey.surveyRef.index,
     },
+    role: Role.DRep,
+    credential: params.credential,
+    answers: { type: "public", answers: params.answers },
   };
+}
+
+export function validateDrepResponse(
+  definition: SurveyDefinition,
+  response: SurveyResponse
+): string[] {
+  return [...validateDefinition(definition), ...validateResponse(definition, response)];
+}
+
+export function encodeResponseMetadata(response: SurveyResponse): Metadatum {
+  return encodePayload({ type: "responses", responses: [response] });
 }

--- a/src/pages/governance/[hash].tsx
+++ b/src/pages/governance/[hash].tsx
@@ -19,8 +19,8 @@ import { BubbleMap } from "@/components/BubbleMap";
 import { useAppSelector } from "@/store/hooks";
 import {
   useGovernanceActionDetail,
-  // useProposalSurvey,
-  // useProposalSurveyTally,
+  useProposalSurvey,
+  useProposalSurveyTally,
 } from "@/hooks/useGovernanceData";
 import { ArrowLeft } from "lucide-react";
 import type {
@@ -74,7 +74,7 @@ import {
 } from "@/lib/governanceEligibilityOverrides";
 import { VoteTrendTooltip } from "@/components/governance/VoteTrendTooltip";
 import { LazyVoteOnProposal } from "@/components/governance/LazyVoteOnProposal";
-// import { LinkedSurveyPanel } from "@/components/governance/LinkedSurveyPanel";
+import { LinkedSurveyPanel } from "@/components/governance/LinkedSurveyPanel";
 import { ProposalExpiryCard } from "@/components/governance/ProposalExpiryCard";
 import { LiveVotingTab } from "@/components/governance/LiveVotingTab";
 import { ProposalDetailsTab } from "@/components/governance/ProposalDetailsTab";
@@ -147,21 +147,18 @@ function GovernanceDetailContent({ initialDetail }: GovernanceDetailProps) {
   // SWR-based data loading with ISR fallback for instant hydration
   const { isLoading: swrLoading, error: swrError, refresh } =
     useGovernanceActionDetail(proposalId, initialDetail);
-  // Hidden until surveys exist on-chain
-  // const {
-  //   survey: proposalSurvey,
-  //   isLoading: isSurveyLoading,
-  //   error: surveyError,
-  // } = useProposalSurvey(proposalId);
-  // const shouldFetchSurveyTally =
-  //   !!proposalSurvey?.linked &&
-  //   !!proposalSurvey.linkValidation.valid &&
-  //   !!proposalSurvey.surveyDetailsValidation.valid;
-  // const {
-  //   tally: proposalSurveyTally,
-  //   isLoading: isSurveyTallyLoading,
-  //   error: surveyTallyError,
-  // } = useProposalSurveyTally(proposalId, shouldFetchSurveyTally);
+  const {
+    survey: proposalSurvey,
+    isLoading: isSurveyLoading,
+    error: surveyError,
+  } = useProposalSurvey(proposalId);
+  const shouldFetchSurveyTally =
+    !!proposalSurvey?.linked && proposalSurvey.linkValidation.valid;
+  const {
+    tally: proposalSurveyTally,
+    isLoading: isSurveyTallyLoading,
+    error: surveyTallyError,
+  } = useProposalSurveyTally(proposalId, shouldFetchSurveyTally);
 
   // Redux still has the data (synced by the hook) for components that read from it
   const { selectedAction } = useAppSelector((state) => state.governance);
@@ -1035,7 +1032,8 @@ function GovernanceDetailContent({ initialDetail }: GovernanceDetailProps) {
             {/* Left Column - Tabs for donuts, bubble map, curves, details */}
             <div className="space-y-4 sm:space-y-5 md:space-y-6 lg:col-span-2">
               <Card className={cn(
-                "info-container p-3 sm:p-4 md:p-6 overflow-hidden dark:border-[#0bd1a2] dark:bg-transparent dark:shadow-none dark:rounded-none h-full flex flex-col",
+                "info-container p-3 sm:p-4 md:p-6 overflow-hidden dark:border-[#0bd1a2] dark:bg-transparent dark:shadow-none dark:rounded-none flex flex-col",
+                !proposalSurvey?.linked && "h-full",
                 isGame && "game-voting-card"
               )}>
                 <Tabs
@@ -1266,8 +1264,7 @@ function GovernanceDetailContent({ initialDetail }: GovernanceDetailProps) {
                 </Tabs>
               </Card>
 
-              {/* Hidden until surveys exist on-chain
-              {selectedAction && (
+              {selectedAction && proposalSurvey?.linked && (
                 <LinkedSurveyPanel
                   survey={proposalSurvey}
                   tally={proposalSurveyTally}
@@ -1278,7 +1275,6 @@ function GovernanceDetailContent({ initialDetail }: GovernanceDetailProps) {
                   isGame={isGame}
                 />
               )}
-              */}
 
             </div>
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -7,7 +7,6 @@
  */
 
 import { API_ENDPOINTS } from "@/config/api";
-import { normalizeProposalSurveyResponse } from "@/lib/surveyMetadata";
 import { correctedWithdrawalAmount } from "@/lib/withdrawalAmountOverrides";
 import type {
   GovernanceAction,
@@ -16,8 +15,6 @@ import type {
   VoteRecord,
   NCLYearData,
   NCLDisplayData,
-  ProposalSurveyResponse,
-  ProposalSurveyTallyResponse,
   ProposalReferenceObject,
 } from "@/types/governance";
 import type {
@@ -186,33 +183,6 @@ export async function fetchGovernanceActionDetail(
     return transformGovernanceActionDetail(data);
   } catch (error) {
     console.error(`Failed to fetch proposal ${proposalId}:`, error);
-    return null;
-  }
-}
-
-export async function fetchProposalSurvey(
-  proposalId: string
-): Promise<ProposalSurveyResponse | null> {
-  try {
-    const survey = await fetchApi<ProposalSurveyResponse>(
-      API_ENDPOINTS.proposalSurvey(proposalId)
-    );
-    return normalizeProposalSurveyResponse(survey);
-  } catch (error) {
-    console.error(`Failed to fetch proposal survey ${proposalId}:`, error);
-    return null;
-  }
-}
-
-export async function fetchProposalSurveyTally(
-  proposalId: string
-): Promise<ProposalSurveyTallyResponse | null> {
-  try {
-    return await fetchApi<ProposalSurveyTallyResponse>(
-      API_ENDPOINTS.proposalSurveyTally(proposalId)
-    );
-  } catch (error) {
-    console.error(`Failed to fetch proposal survey tally ${proposalId}:`, error);
     return null;
   }
 }

--- a/src/types/governance.ts
+++ b/src/types/governance.ts
@@ -230,112 +230,22 @@ export interface GovernanceActionDetail extends GovernanceAction {
   ccVotes?: VoteRecord[]; // Constitutional Committee votes
 }
 
-export type ResponderRole = "DRep" | "SPO" | "CC" | "Stakeholder";
-
-export type SurveyWeightingMode =
-  | "CredentialBased"
-  | "StakeBased"
-  | "PledgeBased";
-
-export interface SurveyNumericConstraints {
-  minValue: number;
-  maxValue: number;
-  step?: number;
-}
-
-export interface SurveyQuestion {
-  questionId: string;
-  question: string;
-  methodType: string;
-  options?: string[];
-  maxSelections?: number;
-  numericConstraints?: SurveyNumericConstraints;
-  methodSchemaUri?: string;
-  methodSchemaHash?: string;
-}
-
-export interface SurveyDetails {
-  specVersion: string;
-  title: string;
-  description: string;
-  questions: SurveyQuestion[];
-  roleWeighting: Partial<Record<ResponderRole, SurveyWeightingMode>>;
-  endEpoch: number;
-}
-
 export interface ProposalSurveyResponse {
   linked: boolean;
-  surveyTxId: string | null;
+  surveyRef: { txId: string; index: number } | null;
   linkValidation: {
     valid: boolean;
     errors: string[];
-    actionEligibility?: ResponderRole[];
-    linkedRoleWeighting?:
-      | Partial<Record<ResponderRole, SurveyWeightingMode>>
-      | null;
-    linkedActionId?: {
-      txId: string;
-      govActionIx: number;
-    } | null;
+    linkedActions: string[];
   };
-  surveyDetails: SurveyDetails | null;
-  surveyDetailsValidation: {
-    valid: boolean;
-    errors: string[];
-  };
+  phase: "open" | "closed" | "cancelled" | "unavailable";
+  bundle: import("cip-179/domain").SurveyBundle | null;
 }
-
-export interface ProposalSurveyMethodResult {
-  [key: string]: unknown;
-}
-
-export interface ProposalSurveyRoleResult {
-  responderRole: ResponderRole;
-  weightingMode: SurveyWeightingMode;
-  totals: {
-    totalSeen: number;
-    valid: number;
-    invalid: number;
-    deduped: number;
-    uniqueResponders: number;
-  };
-  methodResults: ProposalSurveyMethodResult[];
-}
-
-export type ProposalSurveyTallyPhase =
-  | "provisional"
-  | "finalization_pending"
-  | "finalized";
 
 export interface ProposalSurveyTallyResponse {
-  surveyTxId: string | null;
-  phase: ProposalSurveyTallyPhase;
-  asOfEpoch: number | null;
-  finalizationEpoch: number | null;
-  totals: {
-    totalSeen: number;
-    valid: number;
-    invalid: number;
-    deduped: number;
-    uniqueResponders: number;
-  };
-  roleResults: ProposalSurveyRoleResult[];
+  phase: "open" | "finalization_pending" | "finalized" | "unsupported";
+  artifact: import("cip-179/tally").TallyArtifact | null;
   errors: string[];
-  warnings: string[];
-}
-
-export interface SurveyResponseAnswer {
-  questionId: string;
-  selection?: number[];
-  numericValue?: number;
-  customValue?: unknown;
-}
-
-export interface SurveyResponsePayload {
-  specVersion: string;
-  surveyTxId: string;
-  responderRole: ResponderRole;
-  answers: SurveyResponseAnswer[];
 }
 
 /**


### PR DESCRIPTION
  ## Summary

  Updates CGov’s existing CIP-179 implementation to the stable v5 specification, superseding the earlier implementation introduced in [#109](https://github.com/nomos-guild/cgov/pull/109).

  - Replaces the legacy local codec with the reusable `cip-179` package.
  - Renders linked surveys and their presentation metadata on governance action pages.
  - Supports the v5 public survey question and response types available to DReps.
  - Encodes survey responses as native CIP-179 label-17 transaction metadata alongside the governance vote.
  - Handles invalid, closed, unsupported, and unavailable surveys without blocking the governance vote.
  - Fixes survey input stability and linked-survey page layout.

  This frontend change is intended to be used with the companion `cgov-api` [CIP-179 v5 PR.](https://github.com/nomos-guild/cgov-api/pull/70)

  ## Verification

  - `npm run lint`
  - `npm run test:cip179`
  - `npx tsc --noEmit`

  All four focused CIP-179 tests pass. The only lint warning is an existing unrelated `<img>` warning in `AIChatPanel.tsx`.
